### PR TITLE
Hotfix/block until ready

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.2.2
+- Fix issue when segment_store was never invoked
+
 3.2.0
 - Add impression labeling
 

--- a/lib/cache/stores/segment_store.rb
+++ b/lib/cache/stores/segment_store.rb
@@ -30,7 +30,7 @@ module SplitIoClient
 
         def segments_thread
           @sdk_blocker.segments_thread = Thread.new do
-            @config.block_until_ready ? blocked_store : unblocked_store
+            @config.block_until_ready > 0 ? blocked_store : unblocked_store
           end
         end
 

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '3.2.1'
+  VERSION = '3.2.2'
 end


### PR DESCRIPTION
I've changed `block_until_ready` to be always an `Integer` (it used to be `false` when turned off).

Now, when someone wants to turn BUR off it is set to `0` (even if `false` is used in the config, I convert it to be `0` internally). Since `0` in Ruby is truthy [this line](https://github.com/splitio/ruby-client/pull/121/commits/8050b20fb522d115b657f62783a43feab13bea46#diff-eb20af09bc4014bdd396750c388d9d6bL33) always returned `true` and `blocked_store` was called, which led to that no segments were actually stored.