### PR TITLE
Add version spec to concurrent-ruby gem

### DIFF
--- a/splitclient-rb.gemspec
+++ b/splitclient-rb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "json", "~> 1.8"
   spec.add_runtime_dependency "thread_safe"
-  spec.add_runtime_dependency "concurrent-ruby"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday-http-cache"
   spec.add_runtime_dependency "faraday_middleware"

--- a/splitclient-rb.gemspec
+++ b/splitclient-rb.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "json", "~> 1.8"
   spec.add_runtime_dependency "thread_safe"
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faraday-http-cache"
   spec.add_runtime_dependency "faraday_middleware"


### PR DESCRIPTION
Because of its use of Concurrent::Map, this gem requires concurrent-ruby to be at least on version 1.0.0.

Not declaring this causes awkward scenarios where that dependency is not satisfied and the gem fails at runtime when not finding the missing concurrent-ruby classes.