### PR TITLE
Fix ip address fetching

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+4.2.1 (July 11, 2017)
+- Fix IP address fetching
+
 4.2.0 (June 8, 2017)
 - Add support for split dependency on other splits
 - Pass bucketing_key to `match?` method

--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -334,7 +334,12 @@ module SplitIoClient
     #
     # @return [string]
     def self.get_ip
-      Socket.ip_address_list.detect { |intf| intf.ipv4_private? || intf.ipv4_loopback? }.ip_address
+      loopback_ip = Socket.ip_address_list.find { |ip| ip.ipv4_loopback? }
+      private_ip = Socket.ip_address_list.find { |ip| ip.ipv4_private? }
+
+      addr_info = private_ip || loopback_ip
+
+      addr_info.ip_address
     end
   end
 end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '4.2.0'
+  VERSION = '4.2.1'
 end


### PR DESCRIPTION
This PR fixes an issue when Ruby SDK fetches the array of IP addresses and just returns the first one which is loopback or private, which is wrong. Now it first checks for the private and if and only if none found it returns loopback