### PR TITLE
Move passenger threads fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+4.4.0 (September 4, 2017)
+- Extract passenger threads fix to the separate file
+
 4.3.0 (August 7, 2017)
 - Add impression listener
 

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -480,6 +480,16 @@ end
 
 By doing that SDK will recreate threads for each new worker, besides master.
 
+#### Phusion Passenger
+
+Passenger users will have to include this in the config file `config/passenger.rb`:
+
+```ruby
+PhusionPassenger.on_event(:starting_worker_process) do |forked|
+  Rails.configuration.split_factory.resume! if forked
+end
+```
+
 ## Framework support
 
 Currently SDK supports:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+4.4.0
+
+Extract passenger threads fix to the separate file
+
 4.3.0
 
 Add support for impression listener, there is an ability to use user-defined class to capture all impressions

--- a/lib/splitclient-rb/cache/stores/segment_store.rb
+++ b/lib/splitclient-rb/cache/stores/segment_store.rb
@@ -17,12 +17,6 @@ module SplitIoClient
             store_segments
           else
             segments_thread
-
-            if defined?(PhusionPassenger)
-              PhusionPassenger.on_event(:starting_worker_process) do |forked|
-                segments_thread if forked
-              end
-            end
           end
         end
 

--- a/lib/splitclient-rb/cache/stores/split_store.rb
+++ b/lib/splitclient-rb/cache/stores/split_store.rb
@@ -17,12 +17,6 @@ module SplitIoClient
             store_splits
           else
             splits_thread
-
-            if defined?(PhusionPassenger)
-              PhusionPassenger.on_event(:starting_worker_process) do |forked|
-                splits_thread if forked
-              end
-            end
           end
         end
 

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '4.3.0'
+  VERSION = '4.4.0'
 end

--- a/spec/cache/routers/impression_router_spec.rb
+++ b/spec/cache/routers/impression_router_spec.rb
@@ -24,7 +24,7 @@ describe SplitIoClient::ImpressionRouter do
   it 'logs multiple impressions' do
     expect(dbl).to receive(:log).at_least(1).times
 
-    sleep 1
+    sleep 2
 
     described_class.new(config).add_bulk(impressions)
   end


### PR DESCRIPTION
I've assigned version 4.4.0 to this tiny fix to draw users' attention to it, this is potentially breaking changes. We'll need to notify all our customers, who use passenger add the fix manually, see: https://github.com/splitio/ruby-client/blob/feature/move_passenger_threads_fix/Detailed-README.md#phusion-passenger