### PR TITLE
Fix post-fork documentation for Unicorn and Puma

### DIFF
--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -462,23 +462,23 @@ If you're using Unicorn you'll need to include this line in your Unicorn config 
 
 ```ruby
 after_fork do |server, worker|
-  Rails.configuration.split_factory.resume! if worker.nr > 0
+  Rails.configuration.split_factory.resume!
 end
 ```
 
-By doing that SDK will recreate threads for each new worker, besides master.
+By doing that SDK will recreate threads for each new worker.
 
 #### Puma
 
 For those who use Puma in cluster mode add this to your Puma config (probably `config/puma.rb`):
 
 ```ruby
-on_worker_boot do |worker_number|
-  Rails.configuration.split_factory.resume! if worker_number.nr > 0
+on_worker_boot do
+  Rails.configuration.split_factory.resume!
 end
 ```
 
-By doing that SDK will recreate threads for each new worker, besides master.
+By doing that SDK will recreate threads for each new worker.
 
 ## Proxy support
 


### PR DESCRIPTION
The [documentation for Unicorn's after_fork](https://bogomips.org/unicorn/Unicorn/Configurator.html#method-i-after_fork) and the [documentation for Puma's on_worker_boot](https://www.rubydoc.info/github/puma/puma/Puma%2FConfiguration%2FDSL%3Aon_worker_boot) both suggest that the block supplied to each method is called _once per worker process_, and never for the master process.

My own quick and dirty tests corroborate the documentation. (Happy to supply gists if needed.)

In practice (with Puma, since we don't use Unicorn): the value passed to the `on_worker_boot` block is an `Integer`, which doesn't respond to `nr`- which makes for a confidence-uninspiring integrating experience.

Additionally, leaving `if worker_number.nr > 0` in place prevents the SDK from closing its TCP connections (which I understand to be non-persistent, since they're used for HTTP requests), causing sockets to be stuck in `CLOSE_WAIT`:

```
# lsof | grep CLOSE_WAIT
bundle       63           root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
ruby-time    64    65     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    63    66     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    63    69     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
reactor.r    63    80     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63    81     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63    82     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
server.rb    63    83     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio    63   254     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  6291     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  7474     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  7510     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  8234     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  8351     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63  8397     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63 18606     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    63 21911     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
bundle       67           root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
ruby-time    67    70     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    67    77     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
split_sto    67    84     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
segment_s    67    85     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
metrics_s    67    86     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio    67    87     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
events_se    67    88     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    67    89     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
reactor.r    67   137     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67   138     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67   140     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
server.rb    67   141     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio    67   255     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  7604     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  7758     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  7794     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  7795     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  7796     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  8065     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  8070     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    67  8071     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
bundle       97           root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
ruby-time    97    99     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    97   100     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
split_sto    97   101     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
segment_s    97   102     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
metrics_s    97   103     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio    97   104     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
events_se    97   105     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r    97   106     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
reactor.r    97   132     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97   133     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97   134     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
server.rb    97   135     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio    97   253     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7579     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7584     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7625     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7642     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7805     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7807     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97  7878     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po    97 11577     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
bundle      112           root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
ruby-time   112   116     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r   112   117     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
split_sto   112   118     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
segment_s   112   119     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
metrics_s   112   120     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio   112   121     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
events_se   112   122     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
cluster.r   112   123     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
reactor.r   112   146     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112   147     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112   148     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
server.rb   112   149     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
impressio   112   247     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  4871     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  7415     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  7417     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  7836     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  7863     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  8023     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  8366     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
thread_po   112  8367     root    8u     IPv4            9126906       0t0      TCP c11949907d4d:52224->151.101.202.2:https (CLOSE_WAIT)
```

Removing `if worker_number.nr > 0` seems to do the job of allowing the SDK to close its end of finished TCP connections:

```
# lsof | grep CLOSE_WAIT
#
```

Again, I haven't thoroughly tested the Unicorn bits, but I suspect the behavior there is the same as it is for Puma.