### PR TITLE
Handle not having an impression listener

### DIFF
--- a/lib/splitclient-rb/cache/routers/impression_router.rb
+++ b/lib/splitclient-rb/cache/routers/impression_router.rb
@@ -41,7 +41,8 @@ module SplitIoClient
       @config.threads[:impression_router] = Thread.new do
         loop do
           begin
-            @listener.log(@queue.pop)
+            impression = @queue.pop
+            @listener.log(impression) if @listener
           rescue StandardError => error
             @config.log_found_exception(__method__.to_s, error)
           end


### PR DESCRIPTION
It's unclear from the various READMEs whether a custom [impression listener](https://github.com/splitio/ruby-client/blob/master/Detailed-README.md#impression-listener) is _required_ to use the SDK, but if I don't specify one, and configure my logger to output to `stdout`, I see a bunch of lines like this:

```
W, [2018-05-09T10:56:57.530350 #16362]  WARN -- : [splitclient-rb] Unexpected exception in router_thread: #<NoMethodError: undefined method `log' for nil:NilClass                                                                            
Did you mean?  loop> undefined method `log' for nil:NilClass
Did you mean?  loop
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:44:in `block (2 levels) in router_thread'                                                                                
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `loop'                                                                                                             
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `block in router_thread'                                                                                           
W, [2018-05-09T10:56:57.532346 #16362]  WARN -- : [splitclient-rb] Unexpected exception in router_thread: #<NoMethodError: undefined method `log' for nil:NilClass                                                                            
Did you mean?  loop> undefined method `log' for nil:NilClass
Did you mean?  loop
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:44:in `block (2 levels) in router_thread'                                                                                
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `loop'                                                                                                             
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `block in router_thread'                                                                                           
W, [2018-05-09T10:56:57.533696 #16362]  WARN -- : [splitclient-rb] Unexpected exception in router_thread: #<NoMethodError: undefined method `log' for nil:NilClass                                                                            
Did you mean?  loop> undefined method `log' for nil:NilClass
Did you mean?  loop
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:44:in `block (2 levels) in router_thread'                                                                                
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `loop'                                                                                                             
        /Users/henry/.gem/ruby/2.3.1/gems/splitclient-rb-4.5.1/lib/splitclient-rb/cache/routers/impression_router.rb:42:in `block in router_thread'
```

I have a workaround in place so this isn't blocking integration or deployment, but yeah- here's a PR to handle that case (and some re-enabled and faster tests for `ImpressionRouter`, too).