### PR TITLE
Adds stop! method to the factory

### DIFF
--- a/lib/splitclient-rb/split_factory.rb
+++ b/lib/splitclient-rb/split_factory.rb
@@ -30,6 +30,10 @@ module SplitIoClient
       SplitAdapter.new(@api_key, @config, @splits_repository, @segments_repository, @impressions_repository, @metrics_repository, @events_repository, @sdk_blocker)
     end
 
+    def stop!
+      @config.threads.each { |_, t| t.exit }
+    end
+
     alias resume! start!
   end
 end


### PR DESCRIPTION
In this PR we added the stop! method to the split factory and also updated the Detailed-Readme.md.
With this method the user will be able to stop the threads that queries the Split Service. This will be used in the `before_fork` configuration in Puma and Unicorn to stop the threads in the master process.