### PR TITLE
Turn Impression Listener into an optional SDK feature

### DIFF
--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -366,7 +366,9 @@ transport_debug_enabled: true # used for log transport data (mostly http request
 
 ### Impression Listener
 
-In order to capture every single impression in your app SDK provides option called Impression Listener. It works pretty straightforward: you define a class which must have instance method called `log`, which must receive 1 argument `impression`. Let's say you have the following impression listener class:
+The SDK provides an optional featured called Impression Listener, that captures every single impression in your app.
+
+To set up an Impression Listener, define a class that implements a `log` instance method, which must receive the `impression` argument. As an example you could define your listener as follows:
 
 ```ruby
 class MyImpressionListener
@@ -376,7 +378,7 @@ class MyImpressionListener
 end
 ```
 
-Nothing fancy here, it just takes impression and logs it to the stdout. Now, to actually use this class you'll need to specify it in your config (i.e. initializer) like this:
+Nothing fancy here, the listener just takes an impression and logs it to the stdout. Now, to actually use this class you'll need to specify it as an option in your config (i.e. initializer) like this:
 
 ```ruby
 {

--- a/lib/splitclient-rb/cache/routers/impression_router.rb
+++ b/lib/splitclient-rb/cache/routers/impression_router.rb
@@ -5,6 +5,9 @@ module SplitIoClient
     def initialize(config)
       @config = config
       @listener = config.impression_listener
+
+      return unless @listener
+
       @queue = Queue.new
       router_thread
 
@@ -16,12 +19,12 @@ module SplitIoClient
     end
 
     def add(impression)
-      @queue.push(impression)
+      enqueue(impression)
     end
 
     def add_bulk(impressions)
       impressions[:split_names].each do |split_name|
-        @queue.push(
+        enqueue(
           split_name: split_name.to_s,
           matching_key: impressions[:matching_key],
           bucketing_key: impressions[:bucketing_key],
@@ -36,6 +39,10 @@ module SplitIoClient
     end
 
     private
+
+    def enqueue(impression)
+      @queue.push(impression) if @listener
+    end
 
     def router_thread
       @config.threads[:impression_router] = Thread.new do

--- a/lib/splitclient-rb/clients/split_client.rb
+++ b/lib/splitclient-rb/clients/split_client.rb
@@ -144,9 +144,8 @@ module SplitIoClient
 
     def store_impression(split_name, matching_key, bucketing_key, treatment, store_impressions, attributes)
       time = (Time.now.to_f * 1000.0).to_i
-      route_impression(split_name, matching_key, bucketing_key, time, treatment, attributes) if @config.impression_listener && store_impressions
 
-      return if @config.impressions_queue_size <= 0 || !store_impressions
+      return unless @config.impressions_queue_size > 0 && store_impressions
 
       @impressions_repository.add(split_name,
         'keyName' => matching_key,
@@ -156,6 +155,9 @@ module SplitIoClient
         'time' => time,
         'changeNumber' => treatment[:change_number]
       )
+
+      route_impression(split_name, matching_key, bucketing_key, time, treatment, attributes)
+
     rescue StandardError => error
       @config.log_found_exception(__method__.to_s, error)
     end

--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -22,6 +22,7 @@ module SplitIoClient
     # @option opts [Object] :logger a logger to user for messages from the client. Defaults to stdout
     # @option opts [Boolean] :debug_enabled (false) The value for the debug flag
     # @option opts [Int] :impressions_queue_size how big the impressions queue is before dropping impressions. -1 to disable it.
+    # @option opts [#log] :impression_listener this object will capture all impressions and process them through `#log`
     #
     # @return [type] SplitConfig with configuration options
     def initialize(opts = {})

--- a/spec/cache/routers/impression_router_spec.rb
+++ b/spec/cache/routers/impression_router_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::ImpressionRouter do
-  let(:dbl) { double }
-  let(:config) { SplitIoClient::SplitConfig.new(impression_listener: dbl) }
-  let(:impressions) do {
+  let(:listener) { double }
+  let(:config) { SplitIoClient::SplitConfig.new(impression_listener: listener) }
+  let(:impressions) do
+    {
       split_names: %w(ruby ruby_1),
       matching_key: 'dan',
       bucketing_key: nil,
@@ -15,19 +16,67 @@ describe SplitIoClient::ImpressionRouter do
     }
   end
 
-  xit 'logs single impression' do
-    expect(dbl).to receive(:log).with(foo: 'foo')
+  let(:impression_router) { described_class.new(config) }
 
-    sleep 1
-
-    described_class.new(config).add(foo: 'foo')
+  # Pass execution from the main thread to the subject's router_thread
+  # to let the router_thread process the impression queue.
+  #
+  # Assumes ImpressionRouter#initialize starts router_thread and
+  # Queue#pop suspends its calling thread when the receiver is empty.
+  def wait_for_router_thread
+    Thread.pass until config.threads[:impression_router].status != 'run'
   end
 
-  xit 'logs multiple impressions' do
-    expect(dbl).to receive(:log).at_least(1).times
+  describe '#add' do
+    context 'when the config specifies an impression listener' do
+      it 'logs a single impression' do
+        expect(listener).to receive(:log).with(foo: 'foo')
 
-    sleep 1
+        impression_router.add(foo: 'foo')
 
-    described_class.new(config).add_bulk(impressions)
+        wait_for_router_thread
+        expect(config.threads[:impression_router]).not_to be_nil
+        expect(impression_router.instance_variable_get(:@queue)).not_to be_nil
+      end
+    end
+
+    context 'when the config does not specify an impression listener' do
+      let(:listener) { nil }
+
+      it 'ignores single impressions' do
+        expect(config).not_to receive(:log_found_exception)
+
+        impression_router.add(foo: 'foo')
+        expect(config.threads[:impression_router]).to be_nil
+        expect(impression_router.instance_variable_get(:@queue)).to be_nil
+      end
+    end
+  end
+
+  describe '#add_bulk' do
+    context 'when the config specifies an impression listener' do
+      it 'logs multiple impressions' do
+        expect(listener).to receive(:log).twice
+
+        impression_router.add_bulk(impressions)
+
+        wait_for_router_thread
+        expect(config.threads[:impression_router]).not_to be_nil
+        expect(impression_router.instance_variable_get(:@queue)).not_to be_nil
+      end
+    end
+
+    context 'when the config does not specify an impression listener' do
+      let(:listener) { nil }
+
+      it 'ignores multiple impressions' do
+        expect(config).not_to receive(:log_found_exception)
+
+        impression_router.add_bulk(impressions)
+
+        expect(config.threads[:impression_router]).to be_nil
+        expect(impression_router.instance_variable_get(:@queue)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
User feedback has made us aware that the documentation does not reflect whether using an impression listener is required as part of setting up the Split SDK. In fact, failure to do so, currently ends up in exceptions being raised in the `ImpressionRouter` class. 

This proposal turns impression listener into an optional feature, and prevents the impression thread from being started if a listener is not in place. Also, updates the `split_client` logic a bit, making it more readable, and delegating the check for an impression listener instance to the impression router class.

Finally, it updates the documentation to clarify that impression listener is now an optional feature. 