### PR TITLE
Refactor Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ lib/murmurhash/murmurhash.so
 
 ext/murmurhash/murmurhash.bundle
 ext/murmurhash/murmurhash.so
+
+#Ignore dump.rdb
+dump.rdb

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -468,7 +468,7 @@ The gem uses `rspec` for unit testing. You can find the files for the unit tests
 To run all the specs in the `spec` folder, use the provided rake task (_make sure Redis is running in localhost_):
 
 ```bash
-  SPLITCLIENT_ENV=test bundle exec rspec spec
+  bundle exec rspec
 ```
 
 `Simplecov` is used for coverage reporting. Upon executing the rake task it will store the reports in the `/coverage` folder.

--- a/lib/splitclient-rb/cache/repositories/events/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events/memory_repository.rb
@@ -5,16 +5,15 @@ module SplitIoClient
         class MemoryRepository < EventsRepository
           EVENTS_SLICE = 100
 
-          def initialize(adapter, config)
+          def initialize(adapter)
             @adapter = adapter
-            @config = config
           end
 
           def add(key, traffic_type, event_type, time, value)
             @adapter.add_to_queue(m: metadata, e: event(key, traffic_type, event_type, time, value))
           rescue ThreadError # queue is full
-            if @config.debug_enabled
-              @config.logger.warn("Dropping events. Current size is #{@config.events_queue_size}. " \
+            if SplitIoClient.configuration.debug_enabled
+              SplitIoClient.configuration.logger.warn("Dropping events. Current size is #{SplitIoClient.configuration.events_queue_size}. " \
                                   "Consider increasing events_queue_size")
             end
             @adapter.clear

--- a/lib/splitclient-rb/cache/repositories/events/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events/redis_repository.rb
@@ -5,9 +5,8 @@ module SplitIoClient
         class RedisRepository < EventsRepository
           EVENTS_SLICE = 100
 
-          def initialize(adapter, config)
+          def initialize(adapter)
             @adapter = adapter
-            @config = config
           end
 
           def add(key, traffic_type, event_type, time, value)

--- a/lib/splitclient-rb/cache/repositories/events_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events_repository.rb
@@ -6,13 +6,12 @@ module SplitIoClient
         extend Forwardable
         def_delegators :@adapter, :add, :clear
 
-        def initialize(adapter, config)
-          @config = config
+        def initialize(adapter)
           @adapter = case adapter.class.to_s
           when 'SplitIoClient::Cache::Adapters::MemoryAdapter'
-            Repositories::Events::MemoryRepository.new(adapter, config)
+            Repositories::Events::MemoryRepository.new(adapter)
           when 'SplitIoClient::Cache::Adapters::RedisAdapter'
-            Repositories::Events::RedisRepository.new(adapter, config)
+            Repositories::Events::RedisRepository.new(adapter)
           end
         end
 
@@ -20,9 +19,9 @@ module SplitIoClient
 
         def metadata
           {
-            s: "#{@config.language}-#{@config.version}",
-            i: @config.machine_ip,
-            n: @config.machine_name
+            s: "#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}",
+            i: SplitIoClient.configuration.machine_ip,
+            n: SplitIoClient.configuration.machine_name
           }
         end
 

--- a/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
@@ -4,9 +4,8 @@ module SplitIoClient
       module Impressions
         class MemoryRepository
 
-          def initialize(adapter, config)
+          def initialize(adapter)
             @adapter = adapter
-            @config = config
           end
 
           # Store impression data in the selected adapter
@@ -14,7 +13,7 @@ module SplitIoClient
             @adapter.add_to_queue(feature: split_name, impressions: data)
           rescue ThreadError # queue is full
             if random_sampler.rand(1..1000) <= 2 # log only 0.2 % of the time
-              @config.logger.warn("Dropping impressions. Current size is #{@config.impressions_queue_size}. " \
+              SplitIoClient.configuration.logger.warn("Dropping impressions. Current size is #{SplitIoClient.configuration.impressions_queue_size}. " \
                                   "Consider increasing impressions_queue_size")
             end
           end
@@ -26,7 +25,7 @@ module SplitIoClient
                 'keyName' => key,
                 'bucketingKey' => bucketing_key,
                 'treatment' => treatment[:treatment],
-                'label' => @config.labels_enabled ? treatment[:label] : nil,
+                'label' => SplitIoClient.configuration.labels_enabled ? treatment[:label] : nil,
                 'changeNumber' => treatment[:change_number],
                 'time' => time
               )
@@ -34,9 +33,9 @@ module SplitIoClient
           end
 
           def get_batch
-            return [] if @config.impressions_bulk_size == 0
-            @adapter.get_batch(@config.impressions_bulk_size).map do |impression|
-              impression.update(ip: @config.machine_ip)
+            return [] if SplitIoClient.configuration.impressions_bulk_size == 0
+            @adapter.get_batch(SplitIoClient.configuration.impressions_bulk_size).map do |impression|
+              impression.update(ip: SplitIoClient.configuration.machine_ip)
             end
           end
 

--- a/lib/splitclient-rb/cache/repositories/impressions_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions_repository.rb
@@ -6,13 +6,12 @@ module SplitIoClient
         extend Forwardable
         def_delegators :@adapter, :add, :add_bulk, :get_batch, :empty?
 
-        def initialize(adapter, config)
-          @config = config
+        def initialize(adapter)
           @adapter = case adapter.class.to_s
           when 'SplitIoClient::Cache::Adapters::MemoryAdapter'
-            Repositories::Impressions::MemoryRepository.new(adapter, config)
+            Repositories::Impressions::MemoryRepository.new(adapter)
           when 'SplitIoClient::Cache::Adapters::RedisAdapter'
-            Repositories::Impressions::RedisRepository.new(adapter, config)
+            Repositories::Impressions::RedisRepository.new(adapter)
           end
         end
       end

--- a/lib/splitclient-rb/cache/repositories/metrics/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics/memory_repository.rb
@@ -3,12 +3,10 @@ module SplitIoClient
     module Repositories
       module Metrics
         class MemoryRepository
-          def initialize(_ = nil, adapter, config)
+          def initialize(_ = nil, adapter)
             @counts = []
             @latencies = []
             @gauges = []
-
-            @config = config
           end
 
           def add_count(counter, delta)

--- a/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
@@ -3,8 +3,7 @@ module SplitIoClient
     module Repositories
       module Metrics
         class RedisRepository < Repository
-          def initialize(adapter = nil, config)
-            @config = config
+          def initialize(adapter = nil)
             @adapter = adapter
           end
 

--- a/lib/splitclient-rb/cache/repositories/metrics_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics_repository.rb
@@ -7,13 +7,12 @@ module SplitIoClient
         def_delegators :@adapter, :add_count, :add_latency, :add_gauge, :counts, :latencies, :gauges,
                        :clear_counts, :clear_latencies, :clear_gauges, :clear
 
-        def initialize(adapter, config)
-          @config = config
+        def initialize(adapter)
           @adapter = case adapter.class.to_s
           when 'SplitIoClient::Cache::Adapters::MemoryAdapter'
-            Repositories::Metrics::MemoryRepository.new(adapter, config)
+            Repositories::Metrics::MemoryRepository.new(adapter)
           when 'SplitIoClient::Cache::Adapters::RedisAdapter'
-            Repositories::Metrics::RedisRepository.new(adapter, config)
+            Repositories::Metrics::RedisRepository.new(adapter)
           end
         end
       end

--- a/lib/splitclient-rb/cache/repositories/repository.rb
+++ b/lib/splitclient-rb/cache/repositories/repository.rb
@@ -12,11 +12,11 @@ module SplitIoClient
       protected
 
       def namespace_key(key = '')
-        "#{@config.redis_namespace}#{key}"
+        "#{SplitIoClient.configuration.redis_namespace}#{key}"
       end
 
       def impressions_metrics_key(key)
-        namespace_key("/#{@config.language}-#{@config.version}/#{@config.machine_ip}/#{key}")
+        namespace_key("/#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}/#{SplitIoClient.configuration.machine_ip}/#{key}")
       end
     end
   end

--- a/lib/splitclient-rb/cache/repositories/segments_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/segments_repository.rb
@@ -6,10 +6,8 @@ module SplitIoClient
 
         attr_reader :adapter
 
-        def initialize(adapter, config)
+        def initialize(adapter)
           @adapter = adapter
-          @config = config
-
           @adapter.set_bool(namespace_key('.ready'), false)
         end
 

--- a/lib/splitclient-rb/cache/repositories/splits_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/splits_repository.rb
@@ -8,10 +8,8 @@ module SplitIoClient
 
         attr_reader :adapter
 
-        def initialize(adapter, config)
+        def initialize(adapter)
           @adapter = adapter
-          @config = config
-
           @adapter.set_string(namespace_key('.splits.till'), '-1')
           @adapter.initialize_map(namespace_key('.segments.registered'))
         end

--- a/lib/splitclient-rb/cache/routers/impression_router.rb
+++ b/lib/splitclient-rb/cache/routers/impression_router.rb
@@ -2,9 +2,8 @@ module SplitIoClient
   class ImpressionRouter
     attr_reader :router_thread
 
-    def initialize(config)
-      @config = config
-      @listener = config.impression_listener
+    def initialize
+      @listener = SplitIoClient.configuration.impression_listener
 
       return unless @listener
 
@@ -45,12 +44,12 @@ module SplitIoClient
     end
 
     def router_thread
-      @config.threads[:impression_router] = Thread.new do
+      SplitIoClient.configuration.threads[:impression_router] = Thread.new do
         loop do
           begin
             @listener.log(@queue.pop)
           rescue StandardError => error
-            @config.log_found_exception(__method__.to_s, error)
+            SplitIoClient.configuration.log_found_exception(__method__.to_s, error)
           end
         end
       end

--- a/lib/splitclient-rb/cache/senders/events_sender.rb
+++ b/lib/splitclient-rb/cache/senders/events_sender.rb
@@ -2,9 +2,8 @@ module SplitIoClient
   module Cache
     module Senders
       class EventsSender
-        def initialize(events_repository, config, api_key)
+        def initialize(events_repository, api_key)
           @events_repository = events_repository
-          @config = config
           @api_key = api_key
         end
 
@@ -25,21 +24,21 @@ module SplitIoClient
         private
 
         def events_thread
-          @config.threads[:events_sender] = Thread.new do
-            @config.logger.info('Starting events service')
+          SplitIoClient.configuration.threads[:events_sender] = Thread.new do
+            SplitIoClient.configuration.logger.info('Starting events service')
 
             loop do
               post_events
 
-              sleep(SplitIoClient::Utilities.randomize_interval(@config.events_push_rate))
+              sleep(SplitIoClient::Utilities.randomize_interval(SplitIoClient.configuration.events_push_rate))
             end
           end
         end
 
         def post_events
-          SplitIoClient::Api::Events.new(@api_key, @config, @events_repository.clear).post
+          SplitIoClient::Api::Events.new(@api_key, @events_repository.clear).post
         rescue StandardError => error
-          @config.log_found_exception(__method__.to_s, error)
+          SplitIoClient.configuration.log_found_exception(__method__.to_s, error)
         end
       end
     end

--- a/lib/splitclient-rb/cache/senders/metrics_sender.rb
+++ b/lib/splitclient-rb/cache/senders/metrics_sender.rb
@@ -2,9 +2,8 @@ module SplitIoClient
   module Cache
     module Senders
       class MetricsSender
-        def initialize(metrics_repository, config, api_key)
+        def initialize(metrics_repository, api_key)
           @metrics_repository = metrics_repository
-          @config = config
           @api_key = api_key
         end
 
@@ -23,13 +22,13 @@ module SplitIoClient
         private
 
         def metrics_thread
-          @config.threads[:metrics_sender] = Thread.new do
-            @config.logger.info('Starting metrics service')
+          SplitIoClient.configuration.threads[:metrics_sender] = Thread.new do
+            SplitIoClient.configuration.logger.info('Starting metrics service')
 
             loop do
               post_metrics
 
-              sleep(SplitIoClient::Utilities.randomize_interval(@config.metrics_refresh_rate))
+              sleep(SplitIoClient::Utilities.randomize_interval(SplitIoClient.configuration.metrics_refresh_rate))
             end
           end
         end
@@ -37,11 +36,11 @@ module SplitIoClient
         def post_metrics
           metrics_client.post
         rescue StandardError => error
-          @config.log_found_exception(__method__.to_s, error)
+          SplitIoClient.configuration.log_found_exception(__method__.to_s, error)
         end
 
         def metrics_client
-          SplitIoClient::Api::Metrics.new(@api_key, @config, @metrics_repository)
+          SplitIoClient::Api::Metrics.new(@api_key, @metrics_repository)
         end
       end
     end

--- a/lib/splitclient-rb/cache/stores/sdk_blocker.rb
+++ b/lib/splitclient-rb/cache/stores/sdk_blocker.rb
@@ -8,8 +8,7 @@ module SplitIoClient
         attr_reader :splits_repository
         attr_writer :splits_thread, :segments_thread
 
-        def initialize(config, splits_repository, segments_repository)
-          @config = config
+        def initialize(splits_repository, segments_repository)
           @splits_repository = splits_repository
           @segments_repository = segments_repository
 
@@ -27,14 +26,14 @@ module SplitIoClient
 
         def block
           begin
-            Timeout::timeout(@config.block_until_ready) do
+            Timeout::timeout(SplitIoClient.configuration.block_until_ready) do
               sleep 0.1 until ready?
             end
           rescue Timeout::Error
             fail SDKBlockerTimeoutExpiredException, 'SDK start up timeout expired'
           end
 
-          @config.logger.info('SplitIO SDK is ready')
+          SplitIoClient.configuration.logger.info('SplitIO SDK is ready')
           @splits_thread.run
           @segments_thread.run
         end

--- a/lib/splitclient-rb/cache/stores/segment_store.rb
+++ b/lib/splitclient-rb/cache/stores/segment_store.rb
@@ -4,9 +4,8 @@ module SplitIoClient
       class SegmentStore
         attr_reader :segments_repository
 
-        def initialize(segments_repository, config, api_key, metrics, sdk_blocker = nil)
+        def initialize(segments_repository, api_key, metrics, sdk_blocker = nil)
           @segments_repository = segments_repository
-          @config = config
           @api_key = api_key
           @metrics = metrics
           @sdk_blocker = sdk_blocker
@@ -29,9 +28,9 @@ module SplitIoClient
         private
 
         def segments_thread
-          @config.threads[:segment_store] = @sdk_blocker.segments_thread = Thread.new do
-            @config.logger.info('Starting segments fetcher service')
-            @config.block_until_ready > 0 ? blocked_store : unblocked_store
+          SplitIoClient.configuration.threads[:segment_store] = @sdk_blocker.segments_thread = Thread.new do
+            SplitIoClient.configuration.logger.info('Starting segments fetcher service')
+            SplitIoClient.configuration.block_until_ready > 0 ? blocked_store : unblocked_store
           end
         end
 
@@ -40,15 +39,15 @@ module SplitIoClient
             next unless @sdk_blocker.splits_repository.ready?
 
             store_segments
-            @config.logger.debug("Segment names: #{@segments_repository.used_segment_names.to_a}") if @config.debug_enabled
+            SplitIoClient.configuration.logger.debug("Segment names: #{@segments_repository.used_segment_names.to_a}") if SplitIoClient.configuration.debug_enabled
 
             unless @sdk_blocker.ready?
               @sdk_blocker.segments_ready!
-              @config.logger.info('segments are ready')
+              SplitIoClient.configuration.logger.info('segments are ready')
             end
 
-            sleep_for = random_interval(@config.segments_refresh_rate)
-            @config.logger.debug("Segments store is sleeping for: #{sleep_for} seconds") if @config.debug_enabled
+            sleep_for = random_interval(SplitIoClient.configuration.segments_refresh_rate)
+            SplitIoClient.configuration.logger.debug("Segments store is sleeping for: #{sleep_for} seconds") if SplitIoClient.configuration.debug_enabled
             sleep(sleep_for)
           end
         end
@@ -57,14 +56,14 @@ module SplitIoClient
           loop do
             store_segments
 
-            sleep(random_interval(@config.segments_refresh_rate))
+            sleep(random_interval(SplitIoClient.configuration.segments_refresh_rate))
           end
         end
 
         def store_segments
           segments_api.store_segments_by_names(@segments_repository.used_segment_names)
         rescue StandardError => error
-          @config.log_found_exception(__method__.to_s, error)
+          SplitIoClient.configuration.log_found_exception(__method__.to_s, error)
         end
 
         def random_interval(interval)
@@ -74,7 +73,7 @@ module SplitIoClient
         end
 
         def segments_api
-          SplitIoClient::Api::Segments.new(@api_key, @config, @metrics, @segments_repository)
+          SplitIoClient::Api::Segments.new(@api_key, @metrics, @segments_repository)
         end
       end
     end

--- a/lib/splitclient-rb/clients/localhost_split_client.rb
+++ b/lib/splitclient-rb/clients/localhost_split_client.rb
@@ -42,12 +42,12 @@ module SplitIoClient
     # @return [Treatment]  treatment constant value
     def get_treatment(id, feature, attributes = nil)
       unless id
-        @config.logger.warn('id was null for feature: ' + feature)
+        SplitIoClient.configuration.logger.warn('id was null for feature: ' + feature)
         return SplitIoClient::Engine::Models::Treatment::CONTROL
       end
 
       unless feature
-        @config.logger.warn('feature was null for id: ' + id)
+        SplitIoClient.configuration.logger.warn('feature was null for id: ' + id)
         return SplitIoClient::Engine::Models::Treatment::CONTROL
       end
 

--- a/lib/splitclient-rb/engine/api/client.rb
+++ b/lib/splitclient-rb/engine/api/client.rb
@@ -5,39 +5,39 @@ module SplitIoClient
     class Client
       RUBY_ENCODING = '1.9'.respond_to?(:force_encoding)
 
-      def get_api(url, config, api_key, params = {})
+      def get_api(url, api_key, params = {})
         api_client.get(url, params) do |req|
-          req.headers = common_headers(api_key, config).merge('Accept-Encoding' => 'gzip')
+          req.headers = common_headers(api_key).merge('Accept-Encoding' => 'gzip')
 
-          req.options[:timeout] = config.read_timeout
-          req.options[:open_timeout] = config.connection_timeout
+          req.options[:timeout] = SplitIoClient.configuration.read_timeout
+          req.options[:open_timeout] = SplitIoClient.configuration.connection_timeout
 
-          config.logger.debug("GET #{url} proxy: #{api_client.proxy}") if config.debug_enabled
+          SplitIoClient.configuration.logger.debug("GET #{url} proxy: #{api_client.proxy}") if SplitIoClient.configuration.debug_enabled
         end
       rescue StandardError => e
-        config.logger.warn("#{e}\nURL:#{url}\nparams:#{params}")
+        SplitIoClient.configuration.logger.warn("#{e}\nURL:#{url}\nparams:#{params}")
         raise 'Split SDK failed to connect to backend to retrieve information'
       end
 
-      def post_api(url, config, api_key, data, headers = {}, params = {})
+      def post_api(url, api_key, data, headers = {}, params = {})
         api_client.post(url) do |req|
-          req.headers = common_headers(api_key, config)
+          req.headers = common_headers(api_key)
             .merge('Content-Type' => 'application/json')
             .merge(headers)
 
           req.body = data.to_json
 
-          req.options[:timeout] = config.read_timeout
-          req.options[:open_timeout] = config.connection_timeout
+          req.options[:timeout] = SplitIoClient.configuration.read_timeout
+          req.options[:open_timeout] = SplitIoClient.configuration.connection_timeout
 
-          if config.transport_debug_enabled
-            config.logger.debug("POST #{url} #{req.body}")
-          elsif config.debug_enabled
-            config.logger.debug("POST #{url}")
+          if SplitIoClient.configuration.transport_debug_enabled
+            SplitIoClient.configuration.logger.debug("POST #{url} #{req.body}")
+          elsif SplitIoClient.configuration.debug_enabled
+            SplitIoClient.configuration.logger.debug("POST #{url}")
           end
         end
       rescue StandardError => e
-        config.logger.warn("#{e}\nURL:#{url}\ndata:#{data}\nparams:#{params}")
+        SplitIoClient.configuration.logger.warn("#{e}\nURL:#{url}\ndata:#{data}\nparams:#{params}")
 
         false
       end
@@ -51,18 +51,18 @@ module SplitIoClient
         end
       end
 
-      def common_headers(api_key, config)
+      def common_headers(api_key)
         {
           'Authorization' => "Bearer #{api_key}",
-          'SplitSDKVersion' => "#{config.language}-#{config.version}",
-          'SplitSDKMachineName' => config.machine_name,
-          'SplitSDKMachineIP' => config.machine_ip,
-          'Referer' => referer(config)
+          'SplitSDKVersion' => "#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}",
+          'SplitSDKMachineName' => SplitIoClient.configuration.machine_name,
+          'SplitSDKMachineIP' => SplitIoClient.configuration.machine_ip,
+          'Referer' => referer
         }
       end
 
-      def referer(config)
-        result = "#{config.language}-#{config.version}"
+      def referer
+        result = "#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}"
 
         result = "#{result}::#{SplitIoClient::SplitConfig.machine_hostname}" unless SplitIoClient::SplitConfig.machine_hostname == 'localhost'
 

--- a/lib/splitclient-rb/engine/api/impressions.rb
+++ b/lib/splitclient-rb/engine/api/impressions.rb
@@ -1,25 +1,24 @@
 module SplitIoClient
   module Api
     class Impressions < Client
-      def initialize(api_key, config, impressions)
-        @config = config
+      def initialize(api_key, impressions)
         @api_key = api_key
         @impressions = impressions
       end
 
       def post
         if @impressions.empty?
-          @config.logger.debug('No impressions to report') if @config.debug_enabled
+          SplitIoClient.configuration.logger.debug('No impressions to report') if SplitIoClient.configuration.debug_enabled
           return
         end
 
         impressions_by_ip.each do |ip, impressions|
-          result = post_api("#{@config.events_uri}/testImpressions/bulk", @config, @api_key, impressions, 'SplitSDKMachineIP' => ip)
+          result = post_api("#{SplitIoClient.configuration.events_uri}/testImpressions/bulk", @api_key, impressions, 'SplitSDKMachineIP' => ip)
 
           if (200..299).include? result.status
-            @config.logger.debug("Impressions reported: #{total_impressions(@impressions)}") if @config.debug_enabled
+            SplitIoClient.configuration.logger.debug("Impressions reported: #{total_impressions(@impressions)}") if SplitIoClient.configuration.debug_enabled
           else
-            @config.logger.error("Unexpected status code while posting impressions: #{result.status}")
+            SplitIoClient.configuration.logger.error("Unexpected status code while posting impressions: #{result.status}")
           end
         end
       end

--- a/lib/splitclient-rb/engine/api/metrics.rb
+++ b/lib/splitclient-rb/engine/api/metrics.rb
@@ -1,8 +1,7 @@
 module SplitIoClient
   module Api
     class Metrics < Client
-      def initialize(api_key, config, metrics_repository)
-        @config = config
+      def initialize(api_key, metrics_repository)
         @api_key = api_key
         @metrics_repository = metrics_repository
       end
@@ -16,12 +15,12 @@ module SplitIoClient
 
       def post_latencies
         if @metrics_repository.latencies.empty?
-          @config.logger.debug('No latencies to report.') if @config.debug_enabled
+          SplitIoClient.configuration.logger.debug('No latencies to report.') if SplitIoClient.configuration.debug_enabled
         else
           @metrics_repository.latencies.each do |name, latencies|
             metrics_time = { name: name, latencies: latencies }
 
-            result = post_api("#{@config.events_uri}/metrics/time", @config, @api_key, metrics_time)
+            result = post_api("#{SplitIoClient.configuration.events_uri}/metrics/time", @api_key, metrics_time)
 
             log_status(result, metrics_time.size)
           end
@@ -32,12 +31,12 @@ module SplitIoClient
 
       def post_counts
         if @metrics_repository.counts.empty?
-          @config.logger.debug('No counts to report.') if @config.debug_enabled
+          SplitIoClient.configuration.logger.debug('No counts to report.') if SplitIoClient.configuration.debug_enabled
         else
           @metrics_repository.counts.each do |name, count|
             metrics_count = { name: name, delta: count }
 
-            result = post_api("#{@config.events_uri}/metrics/counter", @config, @api_key, metrics_count)
+            result = post_api("#{SplitIoClient.configuration.events_uri}/metrics/counter", @api_key, metrics_count)
 
             log_status(result, metrics_count.size)
           end
@@ -49,11 +48,11 @@ module SplitIoClient
 
       def log_status(result, info_to_log)
         if result == false
-          @config.logger.error("Failed to make a http request")
+          SplitIoClient.configuration.logger.error("Failed to make a http request")
         elsif (200..299).include? result.status
-          @config.logger.debug("Metric time reported: #{info_to_log}") if @config.debug_enabled
+          SplitIoClient.configuration.logger.debug("Metric time reported: #{info_to_log}") if SplitIoClient.configuration.debug_enabled
         else
-          @config.logger.error("Unexpected status code while posting time metrics: #{result.status}")
+          SplitIoClient.configuration.logger.error("Unexpected status code while posting time metrics: #{result.status}")
         end
       end
     end

--- a/lib/splitclient-rb/engine/api/segments.rb
+++ b/lib/splitclient-rb/engine/api/segments.rb
@@ -6,8 +6,7 @@ module SplitIoClient
     class Segments < Client
       METRICS_PREFIX = 'segmentChangeFetcher'
 
-      def initialize(api_key, config, metrics, segments_repository)
-        @config = config
+      def initialize(api_key, metrics, segments_repository)
         @metrics = metrics
         @api_key = api_key
         @segments_repository = segments_repository
@@ -39,7 +38,7 @@ module SplitIoClient
       private
 
       def fetch_segment_changes(name, since)
-        response = get_api("#{@config.base_uri}/segmentChanges/#{name}", @config, @api_key, since: since)
+        response = get_api("#{SplitIoClient.configuration.base_uri}/segmentChanges/#{name}", @api_key, since: since)
 
         if response.success?
           segment = JSON.parse(response.body, symbolize_names: true)

--- a/lib/splitclient-rb/engine/api/splits.rb
+++ b/lib/splitclient-rb/engine/api/splits.rb
@@ -6,16 +6,15 @@ module SplitIoClient
     class Splits < Client
       METRICS_PREFIX = 'splitChangeFetcher'
 
-      def initialize(api_key, config, metrics)
+      def initialize(api_key, metrics)
         @api_key = api_key
-        @config = config
         @metrics = metrics
       end
 
       def since(since)
         start = Time.now
 
-        response = get_api("#{@config.base_uri}/splitChanges", @config, @api_key, since: since)
+        response = get_api("#{SplitIoClient.configuration.base_uri}/splitChanges", @api_key, since: since)
 
         if response.success?
           result = splits_with_segment_names(response.body)

--- a/lib/splitclient-rb/engine/metrics/metrics.rb
+++ b/lib/splitclient-rb/engine/metrics/metrics.rb
@@ -32,12 +32,9 @@ module SplitIoClient
     # @return [int] queue size
     attr_accessor :queue_size
 
-    def initialize(queue_size, config, repository)
+    def initialize(queue_size, repository)
       @queue_size = queue_size
       @binary_search = SplitIoClient::BinarySearchLatencyTracker.new
-
-      @config = config
-
       @repository = repository
     end
 

--- a/lib/splitclient-rb/engine/parser/split_adapter.rb
+++ b/lib/splitclient-rb/engine/parser/split_adapter.rb
@@ -17,7 +17,6 @@ module SplitIoClient
     # Creates a new split api adapter instance that consumes split api endpoints
     #
     # @param api_key [String] the API key for your split account
-    # @param config [SplitConfig] SplitConfig instance
     # @param splits_repository [SplitsRepository] SplitsRepository instance to store splits in
     # @param segments_repository [SegmentsRepository] SegmentsRepository instance to store segments in
     # @param impressions_repository [ImpressionsRepository] ImpressionsRepository instance to store impressions in
@@ -25,18 +24,17 @@ module SplitIoClient
     # @param sdk_blocker [SDKBlocker] SDKBlocker instance which blocks splits_repository/segments_repository
     #
     # @return [SplitIoClient] split.io client instance
-    def initialize(api_key, config, splits_repository, segments_repository, impressions_repository, metrics_repository, events_repository, sdk_blocker)
+    def initialize(api_key, splits_repository, segments_repository, impressions_repository, metrics_repository, events_repository, sdk_blocker)
       @api_key = api_key
-      @config = config
       @splits_repository = splits_repository
       @segments_repository = segments_repository
       @impressions_repository = impressions_repository
       @metrics_repository = metrics_repository
       @events_repository = events_repository
-      @metrics = Metrics.new(100, @config, @metrics_repository)
+      @metrics = Metrics.new(100, @metrics_repository)
       @sdk_blocker = sdk_blocker
 
-      start_based_on_mode(@config.mode)
+      start_based_on_mode(SplitIoClient.configuration.mode)
     end
 
     def start_based_on_mode(mode)
@@ -62,27 +60,27 @@ module SplitIoClient
 
     # Starts thread which loops constantly and stores splits in the splits_repository of choice
     def split_store
-      SplitStore.new(@splits_repository, @config, @api_key, @metrics, @sdk_blocker).call
+      SplitStore.new(@splits_repository, @api_key, @metrics, @sdk_blocker).call
     end
 
     # Starts thread which loops constantly and stores segments in the segments_repository of choice
     def segment_store
-      SegmentStore.new(@segments_repository, @config, @api_key, @metrics, @sdk_blocker).call
+      SegmentStore.new(@segments_repository, @api_key, @metrics, @sdk_blocker).call
     end
 
     # Starts thread which loops constantly and sends impressions to the Split API
     def impressions_sender
-      ImpressionsSender.new(@impressions_repository, @config, @api_key).call
+      ImpressionsSender.new(@impressions_repository, @api_key).call
     end
 
     # Starts thread which loops constantly and sends metrics to the Split API
     def metrics_sender
-      MetricsSender.new(@metrics_repository, @config, @api_key).call
+      MetricsSender.new(@metrics_repository, @api_key).call
     end
 
     # Starts thread which loops constantly and sends events to the Split API
     def events_sender
-      EventsSender.new(@events_repository, @config, @api_key).call
+      EventsSender.new(@events_repository, @api_key).call
     end
   end
 end

--- a/lib/splitclient-rb/managers/split_manager.rb
+++ b/lib/splitclient-rb/managers/split_manager.rb
@@ -6,9 +6,8 @@ module SplitIoClient
     # @param api_key [String] the API key for your split account
     #
     # @return [SplitIoManager] split.io client instance
-    def initialize(api_key, config = {}, adapter = nil, splits_repository = nil)
+    def initialize(api_key, adapter = nil, splits_repository = nil)
       @localhost_mode_features = []
-      @config = config
       @splits_repository = splits_repository
       @adapter = adapter
     end

--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -2,6 +2,15 @@ require 'logger'
 require 'socket'
 
 module SplitIoClient
+
+  class << self
+      attr_accessor :configuration
+  end
+
+  def self.configure(opts={})
+    self.configuration ||= SplitConfig.new(opts)
+  end
+
   #
   # This class manages configuration options for the split client library.
   # If not custom configuration is required the default configuration values will be used
@@ -32,7 +41,7 @@ module SplitIoClient
       @redis_url = opts[:redis_url] || SplitConfig.default_redis_url
       @redis_namespace = opts[:redis_namespace] ? "#{opts[:redis_namespace]}.#{SplitConfig.default_redis_namespace}" : SplitConfig.default_redis_namespace
       @cache_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, @redis_url, false
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter
       )
       @connection_timeout = opts[:connection_timeout] || SplitConfig.default_connection_timeout
       @read_timeout = opts[:read_timeout] || SplitConfig.default_read_timeout
@@ -43,7 +52,7 @@ module SplitIoClient
       @impressions_refresh_rate = opts[:impressions_refresh_rate] || SplitConfig.default_impressions_refresh_rate
       @impressions_queue_size = opts[:impressions_queue_size] || SplitConfig.default_impressions_queue_size
       @impressions_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @redis_url, @impressions_queue_size
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @impressions_queue_size
       )
       #Safeguard for users of older SDK versions.
       @disable_impressions = @impressions_queue_size == -1
@@ -51,7 +60,7 @@ module SplitIoClient
       @impressions_bulk_size = opts[:impressions_bulk_size] || @impressions_queue_size > 0 ? @impressions_queue_size : 0
 
       @metrics_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, @redis_url, false
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter
       )
 
       @logger = opts[:logger] || SplitConfig.default_logger
@@ -74,9 +83,9 @@ module SplitIoClient
       @events_push_rate = opts[:events_push_rate] || SplitConfig.default_events_push_rate
       @events_queue_size = opts[:events_queue_size] || SplitConfig.default_events_queue_size
       @events_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @redis_url, @events_queue_size
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @events_queue_size
       )
-      SplitIoClient::SplitLogger.split_config(self)
+
       startup_log
     end
 
@@ -84,110 +93,110 @@ module SplitIoClient
     # The base URL for split API end points
     #
     # @return [String] The configured base URL for the split API end points
-    attr_reader :base_uri
+    attr_accessor :base_uri
 
     #
     # The base URL for split events API end points
     #
     # @return [String] The configured URL for the events API end points
-    attr_reader :events_uri
+    attr_accessor :events_uri
 
     #
     # The mode SDK will run
     #
     # @return [Symbol] One of the available SDK modes: standalone, consumer, producer
-    attr_reader :mode
+    attr_accessor :mode
 
     # The read timeout for network connections in seconds.
     #
     # @return [Int] The timeout in seconds.
-    attr_reader :read_timeout
+    attr_accessor :read_timeout
 
     #
     # The cache adapter to store splits/segments in
     #
     # @return [Object] Cache adapter instance
-    attr_reader :cache_adapter
+    attr_accessor :cache_adapter
 
     #
     # The cache adapter to store impressions in
     #
     # @return [Object] Impressions adapter instance
-    attr_reader :impressions_adapter
+    attr_accessor :impressions_adapter
 
     #
     # The cache adapter to store metrics in
     #
     # @return [Symbol] Metrics adapter
-    attr_reader :metrics_adapter
+    attr_accessor :metrics_adapter
 
     #
     # The cache adapter to store events in
     #
     # @return [Object] Metrics adapter
-    attr_reader :events_adapter
+    attr_accessor :events_adapter
 
     #
     # The connection timeout for network connections in seconds.
     #
     # @return [Int] The connect timeout in seconds.
-    attr_reader :connection_timeout
+    attr_accessor :connection_timeout
 
     #
     # The configured logger. The client library uses the log to
     # print warning and error messages.
     #
     # @return [Logger] The configured logger
-    attr_reader :logger
+    attr_accessor :logger
 
     #
     # The boolean that represents the state of the debug log level
     #
     # @return [Boolean] The value for the debug flag
-    attr_reader :debug_enabled
+    attr_accessor :debug_enabled
 
     #
     # Enable to log the content retrieved from endpoints
     #
     # @return [Boolean] The value for the debug flag
-    attr_reader :transport_debug_enabled
+    attr_accessor :transport_debug_enabled
 
     #
     # Enable logging labels and sending potentially sensitive information
     #
     # @return [Boolean] The value for the labels enabled flag
-    attr_reader :labels_enabled
+    attr_accessor :labels_enabled
 
     #
     # The number of seconds to wait for SDK readiness
     # or false to disable waiting
     # @return [Integer]/[FalseClass]
-    attr_reader :block_until_ready
+    attr_accessor :block_until_ready
 
-    attr_reader :machine_ip
-    attr_reader :machine_name
+    attr_accessor :machine_ip
+    attr_accessor :machine_name
 
-    attr_reader :language
-    attr_reader :version
+    attr_accessor :language
+    attr_accessor :version
 
-    attr_reader :features_refresh_rate
-    attr_reader :segments_refresh_rate
-    attr_reader :metrics_refresh_rate
-    attr_reader :impressions_refresh_rate
+    attr_accessor :features_refresh_rate
+    attr_accessor :segments_refresh_rate
+    attr_accessor :metrics_refresh_rate
+    attr_accessor :impressions_refresh_rate
 
-    attr_reader :impression_listener
-    attr_reader :impression_listener_refresh_rate
+    attr_accessor :impression_listener
+    attr_accessor :impression_listener_refresh_rate
 
     #
     # How big the impressions queue is before dropping impressions. -1 to disable it.
     #
     # @return [Integer]
-    attr_reader :impressions_queue_size
-    attr_reader :impressions_bulk_size
-    attr_reader :disable_impressions
+    attr_accessor :impressions_queue_size
+    attr_accessor :impressions_bulk_size
+    attr_accessor :disable_impressions
 
-    attr_reader :redis_url
-    attr_reader :redis_namespace
+    attr_accessor :redis_url
+    attr_accessor :redis_namespace
 
     attr_accessor :threads
 
@@ -195,13 +204,13 @@ module SplitIoClient
     # The schedule time for events flush after the first one
     #
     # @return [Integer]
-    attr_reader :events_push_rate
+    attr_accessor :events_push_rate
 
     #
     # The max size of the events queue
     #
     # @return [Integer]
-    attr_reader :events_queue_size
+    attr_accessor :events_queue_size
 
     #
     # The default split client configuration
@@ -223,7 +232,7 @@ module SplitIoClient
       'https://events.split.io/api/'
     end
 
-    def self.init_cache_adapter(adapter, data_structure, redis_url = nil, queue_size = nil)
+    def self.init_cache_adapter(adapter, data_structure, queue_size = nil)
       case adapter
       when :memory
         SplitIoClient::Cache::Adapters::MemoryAdapter.new(map_memory_adapter(data_structure, queue_size))
@@ -234,7 +243,7 @@ module SplitIoClient
           fail StandardError, 'To use Redis as a cache adapter you must include it in your Gemfile'
         end
 
-        SplitIoClient::Cache::Adapters::RedisAdapter.new(redis_url)
+        SplitIoClient::Cache::Adapters::RedisAdapter.new(@redis_url)
       end
     end
 

--- a/lib/splitclient-rb/split_logger.rb
+++ b/lib/splitclient-rb/split_logger.rb
@@ -2,23 +2,18 @@ require 'singleton'
 
 module SplitIoClient
   class SplitLogger
-      attr_accessor :config
       include Singleton
 
-      def self.split_config(config)
-        instance.config = config
-      end
-
       def log_if_debug(message)
-        config.logger.debug(message) if config.debug_enabled
+        SplitIoClient.configuration.logger.debug(message) if SplitIoClient.configuration.debug_enabled
       end
 
       def log_if_transport(message)
-        config.logger.debug(message) if config.transport_debug_enabled
+        SplitIoClient.configuration.logger.debug(message) if SplitIoClient.configuration.transport_debug_enabled
       end
 
       def log_error(message)
-        config.logger.error(message)
+        SplitIoClient.configuration.logger.error(message)
       end
 
       class << self

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '5.1.0'
+  VERSION = '5.1.1.pre.rc1'
 end

--- a/spec/allocations/splitclient-rb/clients/split_client_spec.rb
+++ b/spec/allocations/splitclient-rb/clients/split_client_spec.rb
@@ -3,17 +3,16 @@
 require 'spec_helper'
 
 describe SplitIoClient::SplitClient do
-  let(:config) { SplitIoClient::SplitConfig.new }
   let(:map_adapter) { SplitIoClient::Cache::Adapters::MemoryAdapters::MapAdapter.new }
   let(:queue_adapter) { SplitIoClient::Cache::Adapters::MemoryAdapters::QueueAdapter.new(10) }
 
-  let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(map_adapter, config) }
-  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(map_adapter, config) }
-  let(:impressions_repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(queue_adapter, config) }
-  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(map_adapter, config) }
+  let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(map_adapter) }
+  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(map_adapter) }
+  let(:impressions_repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(queue_adapter) }
+  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(map_adapter) }
 
   let(:client) do
-    SplitIoClient::SplitClient.new('', config, splits_repository, segments_repository,
+    SplitIoClient::SplitClient.new('', splits_repository, segments_repository,
                                    impressions_repository, metrics_repository, nil)
   end
 

--- a/spec/cache/repositories/metrics_repository_spec.rb
+++ b/spec/cache/repositories/metrics_repository_spec.rb
@@ -4,9 +4,8 @@ require 'spec_helper'
 
 describe SplitIoClient::Cache::Repositories::MetricsRepository do
   RSpec.shared_examples 'metrics specs' do |cache_adapter|
-    let(:config) { SplitIoClient::SplitConfig.new }
     let(:adapter) { cache_adapter }
-    let(:repository) { described_class.new(adapter, config) }
+    let(:repository) { described_class.new(adapter) }
     let(:binary_search) { SplitIoClient::BinarySearchLatencyTracker.new }
 
     before :each do
@@ -21,6 +20,6 @@ describe SplitIoClient::Cache::Repositories::MetricsRepository do
   end
 
   include_examples 'metrics specs', SplitIoClient::Cache::Adapters::RedisAdapter.new(
-    SplitIoClient::SplitConfig.new.redis_url
+    SplitIoClient::SplitConfig.default_redis_url
   )
 end

--- a/spec/cache/repositories/segments_repository_spec.rb
+++ b/spec/cache/repositories/segments_repository_spec.rb
@@ -5,8 +5,7 @@ require 'spec_helper'
 describe SplitIoClient::Cache::Repositories::SegmentsRepository do
   context 'memory adapter' do
     let(:adapter) { SplitIoClient::Cache::Adapters::MemoryAdapters::MapAdapter.new }
-    let(:config) { SplitIoClient::SplitConfig.new }
-    let(:repository) { described_class.new(adapter, config) }
+    let(:repository) { described_class.new(adapter) }
 
     it 'removes keys' do
       repository.add_to_segment(name: 'foo', added: [1, 2, 3], removed: [])
@@ -18,9 +17,8 @@ describe SplitIoClient::Cache::Repositories::SegmentsRepository do
   end
 
   context 'redis adapter' do
-    let(:config) { SplitIoClient::SplitConfig.new }
-    let(:adapter) { SplitIoClient::Cache::Adapters::RedisAdapter.new(config.redis_url) }
-    let(:repository) { described_class.new(adapter, config) }
+    let(:adapter) { SplitIoClient::Cache::Adapters::RedisAdapter.new(SplitIoClient.configuration.redis_url) }
+    let(:repository) { described_class.new(adapter) }
 
     it 'removes keys' do
       repository.add_to_segment(name: 'foo', added: [1, 2, 3], removed: [])

--- a/spec/cache/repositories/splits_repository_spec.rb
+++ b/spec/cache/repositories/splits_repository_spec.rb
@@ -6,12 +6,12 @@ require 'set'
 describe SplitIoClient::Cache::Repositories::SplitsRepository do
   RSpec.shared_examples 'SplitsRepository specs' do |cache_adapter|
     let(:adapter) { cache_adapter }
-    let(:config) { SplitIoClient::SplitConfig.new(cache_adapter: cache_adapter) }
-    let(:repository) { described_class.new(adapter, config) }
+    let(:repository) { described_class.new(adapter) }
 
     before :all do
       redis = Redis.new
       redis.flushall
+      SplitIoClient.configure(cache_adapter: cache_adapter)
     end
 
     after :all do

--- a/spec/cache/routers/impression_router_spec.rb
+++ b/spec/cache/routers/impression_router_spec.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 
 describe SplitIoClient::ImpressionRouter do
   let(:listener) { double }
-  let(:config) { SplitIoClient::SplitConfig.new(impression_listener: listener) }
   let(:impressions) do
     {
       split_names: %w[ruby ruby_1],
@@ -18,7 +17,7 @@ describe SplitIoClient::ImpressionRouter do
     }
   end
 
-  let(:impression_router) { described_class.new(config) }
+  let(:impression_router) { described_class.new }
 
   # Pass execution from the main thread to the subject's router_thread
   # to let the router_thread process the impression queue.
@@ -26,30 +25,36 @@ describe SplitIoClient::ImpressionRouter do
   # Assumes ImpressionRouter#initialize starts router_thread and
   # Queue#pop suspends its calling thread when the receiver is empty.
   def wait_for_router_thread
-    Thread.pass until config.threads[:impression_router].status != 'run'
+    Thread.pass until SplitIoClient.configuration.threads[:impression_router].status != 'run'
   end
 
   describe '#add' do
     context 'when the config specifies an impression listener' do
       it 'logs a single impression' do
+        SplitIoClient.configuration.impression_listener = listener
         expect(listener).to receive(:log).with(foo: 'foo')
 
         impression_router.add(foo: 'foo')
 
         wait_for_router_thread
-        expect(config.threads[:impression_router]).not_to be_nil
+        expect(SplitIoClient.configuration.threads[:impression_router]).not_to be_nil
         expect(impression_router.instance_variable_get(:@queue)).not_to be_nil
       end
     end
 
     context 'when the config does not specify an impression listener' do
+      before do
+        SplitIoClient.configuration = nil
+        SplitIoClient.configure
+      end
       let(:listener) { nil }
 
       it 'ignores single impressions' do
-        expect(config).not_to receive(:log_found_exception)
+        SplitIoClient.configuration.impression_listener = listener
+        expect(SplitIoClient.configuration).not_to receive(:log_found_exception)
 
         impression_router.add(foo: 'foo')
-        expect(config.threads[:impression_router]).to be_nil
+        expect(SplitIoClient.configuration.threads[:impression_router]).to be_nil
         expect(impression_router.instance_variable_get(:@queue)).to be_nil
       end
     end
@@ -58,25 +63,31 @@ describe SplitIoClient::ImpressionRouter do
   describe '#add_bulk' do
     context 'when the config specifies an impression listener' do
       it 'logs multiple impressions' do
+        SplitIoClient.configuration.impression_listener = listener
         expect(listener).to receive(:log).twice
 
         impression_router.add_bulk(impressions)
 
         wait_for_router_thread
-        expect(config.threads[:impression_router]).not_to be_nil
+        expect(SplitIoClient.configuration.threads[:impression_router]).not_to be_nil
         expect(impression_router.instance_variable_get(:@queue)).not_to be_nil
       end
     end
 
     context 'when the config does not specify an impression listener' do
+      before do
+        SplitIoClient.configuration = nil
+        SplitIoClient.configure
+      end
       let(:listener) { nil }
 
       it 'ignores multiple impressions' do
-        expect(config).not_to receive(:log_found_exception)
+        SplitIoClient.configuration.impression_listener = listener
+        expect(SplitIoClient.configuration).not_to receive(:log_found_exception)
 
         impression_router.add_bulk(impressions)
 
-        expect(config.threads[:impression_router]).to be_nil
+        expect(SplitIoClient.configuration.threads[:impression_router]).to be_nil
         expect(impression_router.instance_variable_get(:@queue)).to be_nil
       end
     end

--- a/spec/cache/senders/impressions_sender_spec.rb
+++ b/spec/cache/senders/impressions_sender_spec.rb
@@ -4,16 +4,15 @@ require 'spec_helper'
 
 describe SplitIoClient::Cache::Senders::ImpressionsSender do
   RSpec.shared_examples 'impressions sender specs' do |cache_adapter|
-    let(:config) { SplitIoClient::SplitConfig.new(impressions_queue_size: 5) }
     let(:adapter) { cache_adapter }
-    let(:repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(adapter, config) }
-    let(:sender) { described_class.new(repository, config, nil) }
+    let(:repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(adapter) }
+    let(:sender) { described_class.new(repository, nil) }
     let(:formatted_impressions) { sender.send(:formatted_impressions, repository.get_batch) }
-    let(:ip) { SplitIoClient::SplitConfig.machine_ip }
+    let(:ip) { SplitIoClient.configuration.machine_ip }
 
     before :each do
       Redis.new.flushall
-
+      SplitIoClient.configuration.impressions_queue_size = 5
       repository.add('foo1',
                      'keyName' => 'matching_key',
                      'bucketingKey' => 'foo1',

--- a/spec/cache/stores/sdk_blocker_spec.rb
+++ b/spec/cache/stores/sdk_blocker_spec.rb
@@ -4,14 +4,14 @@ require 'spec_helper'
 
 describe SplitIoClient::Cache::Stores::SDKBlocker do
   RSpec.shared_examples 'sdk_blocker specs' do |cache_adapter|
-    let(:config) { SplitIoClient::SplitConfig.new(ready: 0.1) }
-    let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(cache_adapter, config) }
-    let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(cache_adapter, config) }
-    let(:sdk_blocker) { described_class.new(config, splits_repository, segments_repository) }
+    let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(cache_adapter) }
+    let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(cache_adapter) }
+    let(:sdk_blocker) { described_class.new(splits_repository, segments_repository) }
 
     before :each do
       redis = Redis.new
       redis.flushall
+      SplitIoClient.configuration.block_until_ready = 0.1
     end
 
     it 'is not ready after initialization' do

--- a/spec/engine/api/segments_spec.rb
+++ b/spec/engine/api/segments_spec.rb
@@ -3,21 +3,21 @@
 require 'spec_helper'
 
 describe SplitIoClient::Api::Segments do
-  let(:log) { StringIO.new }
-  let(:config) do
-    SplitIoClient::SplitConfig.new(
-      logger: Logger.new(log),
-      debug_enabled: true,
-      transport_debug_enabled: true
-    )
+  before do
+    SplitIoClient.configuration.logger = Logger.new(log)
+    SplitIoClient.configuration.debug_enabled = true
+    SplitIoClient.configuration.transport_debug_enabled = true
   end
-  let(:segments_api) { described_class.new('', config, metrics, segments_repository) }
+
+  let(:log) { StringIO.new }
+  let(:segments_api) { described_class.new('', metrics, segments_repository) }
   let(:adapter) do
     SplitIoClient::Cache::Adapters::MemoryAdapter.new(SplitIoClient::Cache::Adapters::MemoryAdapters::MapAdapter.new)
   end
-  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(adapter, config) }
-  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(config.metrics_adapter, config) }
-  let(:metrics) { SplitIoClient::Metrics.new(100, config, metrics_repository) }
+  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(adapter) }
+  let(:metrics_adapter) { SplitIoClient.configuration.metrics_adapter }
+  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(metrics_adapter) }
+  let(:metrics) { SplitIoClient::Metrics.new(100, metrics_repository) }
   let(:segments) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__), '../../test_data/segments/segments.json')))
   end

--- a/spec/engine/api/splits_spec.rb
+++ b/spec/engine/api/splits_spec.rb
@@ -3,17 +3,17 @@
 require 'spec_helper'
 
 describe SplitIoClient::Api::Splits do
-  let(:log) { StringIO.new }
-  let(:config) do
-    SplitIoClient::SplitConfig.new(
-      logger: Logger.new(log),
-      debug_enabled: true,
-      transport_debug_enabled: true
-    )
+  before do
+    SplitIoClient.configuration.logger = Logger.new(log)
+    SplitIoClient.configuration.debug_enabled = true
+    SplitIoClient.configuration.transport_debug_enabled = true
   end
-  let(:splits_api) { described_class.new('', config, metrics) }
-  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(config.metrics_adapter, config) }
-  let(:metrics) { SplitIoClient::Metrics.new(100, config, metrics_repository) }
+
+  let(:log) { StringIO.new }
+  let(:splits_api) { described_class.new('', metrics) }
+  let(:metrics_adapter) { SplitIoClient.configuration.metrics_adapter }
+  let(:metrics_repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(metrics_adapter) }
+  let(:metrics) { SplitIoClient::Metrics.new(100, metrics_repository) }
   let(:splits) { File.read(File.expand_path(File.join(File.dirname(__FILE__), '../../test_data/splits/splits.json'))) }
 
   context '#splits_with_segment_names' do

--- a/spec/engine/matchers/between_matcher_spec.rb
+++ b/spec/engine/matchers/between_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::BetweenMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('').client
+  end
 
   let(:datetime_matcher_splits) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/matchers/combining_matcher_spec.rb
+++ b/spec/engine/matchers/combining_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::CombiningMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
+  end
 
   let(:splits_json) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/matchers/equal_to_matcher_spec.rb
+++ b/spec/engine/matchers/equal_to_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::EqualToMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
+  end
 
   let(:date_splits_json) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/matchers/greater_than_or_equal_to_matcher_spec.rb
+++ b/spec/engine/matchers/greater_than_or_equal_to_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::GreaterThanOrEqualToMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
+  end
 
   let(:date_splits_json) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/matchers/less_than_or_equal_to_matcher_spec.rb
+++ b/spec/engine/matchers/less_than_or_equal_to_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::LessThanOrEqualToMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('').client
+  end
 
   let(:date_splits_json) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/matchers/whitelist_matcher_spec.rb
+++ b/spec/engine/matchers/whitelist_matcher_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient::WhitelistMatcher do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
+  end
 
   let(:splits_json) do
     File.read(File.expand_path(File.join(File.dirname(__FILE__),

--- a/spec/engine/parser/evaluator_spec.rb
+++ b/spec/engine/parser/evaluator_spec.rb
@@ -4,9 +4,8 @@ require 'spec_helper'
 
 describe SplitIoClient::Engine::Parser::Evaluator do
   let(:adapter) { SplitIoClient::Cache::Adapters::MemoryAdapters::MapAdapter.new }
-  let(:config) { SplitIoClient::SplitConfig.new }
-  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(adapter, config) }
-  let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(adapter, config) }
+  let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(adapter) }
+  let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(adapter) }
   let(:evaluator) { described_class.new(segments_repository, splits_repository, true) }
 
   let(:killed_split) { { killed: true, defaultTreatment: 'default' } }

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -6,6 +6,7 @@ require 'securerandom'
 describe SplitIoClient, type: :client do
   RSpec.shared_examples 'engine specs' do |cache_adapter|
     subject do
+      SplitIoClient.configuration = nil
       SplitIoClient::SplitFactory.new('',
                                       logger: Logger.new('/dev/null'),
                                       cache_adapter: cache_adapter,
@@ -106,6 +107,7 @@ describe SplitIoClient, type: :client do
 
       context 'producer mode' do
         subject do
+          SplitIoClient.configuration = nil
           SplitIoClient::SplitFactory.new('',
                                           logger: Logger.new('/dev/null'),
                                           cache_adapter: cache_adapter,
@@ -120,6 +122,7 @@ describe SplitIoClient, type: :client do
 
       context 'consumer mode' do
         subject do
+          SplitIoClient.configuration = nil
           SplitIoClient::SplitFactory.new('',
                                           logger: Logger.new('/dev/null'),
                                           cache_adapter: cache_adapter,
@@ -370,7 +373,7 @@ describe SplitIoClient, type: :client do
       let(:impressions) { subject.instance_variable_get(:@impressions_repository).get_batch }
       let(:formatted_impressions) do
         SplitIoClient::Cache::Senders::ImpressionsSender
-          .new(nil, {}, nil)
+          .new(nil, nil)
           .send(:formatted_impressions, impressions)
       end
 
@@ -400,6 +403,7 @@ describe SplitIoClient, type: :client do
 
       context 'when impressions are disabled' do
         subject do
+          SplitIoClient.configuration = nil
           SplitIoClient::SplitFactory.new('',
                                           logger: Logger.new('/dev/null'),
                                           cache_adapter: cache_adapter,
@@ -467,7 +471,7 @@ describe SplitIoClient, type: :client do
       it 'returns control' do
         expect(subject.get_treatment('fake_user_id_1', 'test_feature')).to eq 'on'
 
-        subject.instance_variable_get(:@config).threads[:impressions_sender] = Thread.new {}
+        SplitIoClient.configuration.threads[:impressions_sender] = Thread.new {}
         subject.destroy
 
         expect(subject.get_treatment('fake_user_id_1', 'test_feature')).to eq 'control'
@@ -494,17 +498,15 @@ describe SplitIoClient, type: :client do
           .to_return(status: 200, body: all_keys_matcher_json)
       end
 
-      let(:split_config) { SplitIoClient::SplitConfig.new }
-
       it 'fetches and deletes events' do
         subject.track('key', 'traffic_type', 'event_type', 'value')
 
         event = subject.instance_variable_get(:@events_repository).clear.first
 
         expect(event[:m]).to eq(
-          s: "#{split_config.language}-#{split_config.version}",
-          i: split_config.machine_ip,
-          n: split_config.machine_name
+          s: "#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}",
+          i: SplitIoClient.configuration.machine_ip,
+          n: SplitIoClient.configuration.machine_name
         )
 
         expect(event[:e].reject { |e| e == :timestamp }).to eq(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
+require 'splitclient-rb'
 require 'concurrent'
 require 'simplecov'
 require 'redis_helper'
+require 'pry'
 SimpleCov.start
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!
 
+ENV['SPLITCLIENT_ENV'] ||= 'test'
+
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.include RSpec::RedisHelper, redis: true
+  config.before(:all) do
+    SplitIoClient.configuration = nil
+    SplitIoClient.configure(logger: Logger.new('/dev/null'))
+  end
 end
-
-require 'splitclient-rb'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }

--- a/spec/splitclient/split_manager_spec.rb
+++ b/spec/splitclient/split_manager_spec.rb
@@ -47,7 +47,7 @@ describe SplitIoClient do
 
   describe 'client destroy' do
     before do
-      factory.client.instance_variable_get(:@config).threads[:impressions_sender] = Thread.new {}
+      SplitIoClient.configuration.threads[:impressions_sender] = Thread.new {}
       factory.client.destroy
     end
 

--- a/spec/splitclient_rb_corner_cases_spec.rb
+++ b/spec/splitclient_rb_corner_cases_spec.rb
@@ -3,7 +3,10 @@
 require 'spec_helper'
 
 describe SplitIoClient do
-  subject { SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client }
+  subject do
+    SplitIoClient.configuration = nil
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
+  end
 
   let(:splits_json) { File.read(File.expand_path(File.join(File.dirname(__FILE__), 'test_data/splits/splits.json'))) }
   let(:segments_json) do


### PR DESCRIPTION
This PR introduces a refactor for the configuration to implement a new pattern that avoids passing the `@config` instance throughout the library classes, clarifying the code thus increasing maintainability.
It also adds:
* Pry as a require in the spec_helpers.rb, allowing to debug while writing specs.
* Add dump.rb to the .gitignore. This is a file that is automatically created when the user runs the specs.
* You can now run the `specs`. Simply by running `bundle exec rspec`