### PR TITLE
Reduce number of Redis calls

### DIFF
--- a/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
@@ -16,7 +16,6 @@ module SplitIoClient
 
           def add_latency(operation, time_in_ms, binary_search)
             prefixed_name = impressions_metrics_key("latency.#{operation}")
-            latencies = @adapter.find_strings_by_prefix(prefixed_name)
 
             if operation == 'sdk.get_treatment'
               @adapter.inc("#{prefixed_name}.#{binary_search.add_latency_millis(time_in_ms, true)}")

--- a/lib/splitclient-rb/cache/repositories/segments_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/segments_repository.rb
@@ -8,7 +8,7 @@ module SplitIoClient
 
         def initialize(adapter)
           @adapter = adapter
-          @adapter.set_bool(namespace_key('.ready'), false)
+          @adapter.set_bool(namespace_key('.ready'), false) unless SplitIoClient.configuration.mode == :consumer
         end
 
         # Receives segment data, adds and removes segements from the store

--- a/lib/splitclient-rb/cache/repositories/splits_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/splits_repository.rb
@@ -8,8 +8,10 @@ module SplitIoClient
 
         def initialize(adapter)
           @adapter = adapter
-          @adapter.set_string(namespace_key('.splits.till'), '-1')
-          @adapter.initialize_map(namespace_key('.segments.registered'))
+          unless SplitIoClient.configuration.mode == :consumer
+            @adapter.set_string(namespace_key('.splits.till'), '-1')
+            @adapter.initialize_map(namespace_key('.segments.registered'))
+          end
         end
 
         def add_split(split)

--- a/spec/cache/repositories/splits_repository_spec.rb
+++ b/spec/cache/repositories/splits_repository_spec.rb
@@ -37,23 +37,24 @@ describe SplitIoClient::Cache::Repositories::SplitsRepository do
       )
     end
 
-    context 'slice is 10' do
-      it 'returns data for multiple splits' do
-        expect(repository.get_splits(%w[foo bar baz], 10)).to eq(
+    context 'empty split names' do
+      it 'returns data for non empty split names' do
+        expect(repository.adapter).to receive(:multiple_strings).once.and_call_original
+        expect(repository.get_splits(['foo', '', 'bar'])).to eq(
           foo: { name: 'foo' },
-          bar: { name: 'bar' },
-          baz: { name: 'baz' }
+          bar: { name: 'bar' }
         )
       end
     end
 
-    context 'slice is 2' do
-      it 'returns data for multiple splits' do
-        expect(repository.get_splits(%w[foo bar baz], 2)).to eq(
+    context 'repeated split names' do
+      it 'returns data for non repeated split names' do
+        expect(repository.adapter).to receive(:multiple_strings).once.and_call_original
+        expect(repository.get_splits(%w[foo foo bar])).to eq(
           foo: { name: 'foo' },
-          bar: { name: 'bar' },
-          baz: { name: 'baz' }
+          bar: { name: 'bar' }
         )
+
       end
     end
   end

--- a/spec/cache/repositories/splits_repository_spec.rb
+++ b/spec/cache/repositories/splits_repository_spec.rb
@@ -54,7 +54,6 @@ describe SplitIoClient::Cache::Repositories::SplitsRepository do
           foo: { name: 'foo' },
           bar: { name: 'bar' }
         )
-
       end
     end
   end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -61,6 +61,12 @@ describe SplitIoClient, type: :client do
           .to_return(status: 200, body: all_keys_matcher_json)
       end
 
+      it 'saves just one metric to Redis' do
+        expect(subject.instance_variable_get(:@adapter).metrics).to receive(:time)
+          .with('sdk.get_treatment', anything).once.and_call_original
+        subject.get_treatment('fake_user_id_1', 'test_feature')
+      end
+
       it 'returns CONTROL for random id' do
         expect(subject.get_treatment('my_random_user_id', 'my_random_feaure'))
           .to eq SplitIoClient::Engine::Models::Treatment::CONTROL
@@ -96,6 +102,19 @@ describe SplitIoClient, type: :client do
           label: SplitIoClient::Engine::Models::Label::DEFINITION_NOT_FOUND,
           change_number: nil
         )
+      end
+    end
+
+    context '#get_treatments' do
+      before do
+        stub_request(:get, 'https://sdk.split.io/api/splitChanges?since=-1')
+          .to_return(status: 200, body: all_keys_matcher_json)
+      end
+
+      it 'saves just one metric to Redis' do
+        expect(subject.instance_variable_get(:@adapter).metrics).to receive(:time)
+          .with('sdk.get_treatments', anything).once.and_call_original
+        subject.get_treatments(222, %w[new_feature foo test_feature])
       end
     end
 


### PR DESCRIPTION
In this PR we:
* Removed unused call to scan.
* Removed sliced calls to Redis on get_splits. Replaced it for 1 call with all the splits names.
* Sanitized splits_names in get_splits method
* Changed get_treatments to save just 1 metric for the whole operation
* Remove calls to Redis no needed on consumer mode