### PR TITLE
Remove producer mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ lib/murmurhash/murmurhash.so
 ext/murmurhash/murmurhash.bundle
 ext/murmurhash/murmurhash.so
 
-#Ignore dump.rdb
+# Ignore dump.rdb
 dump.rdb
+
+# Ignore Mac OS generated files
+.DS_Store

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Documentation:
+    Enabled: false
+
 Metrics/MethodLength:
   Max: 15
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-5.1.0 (October 4th, 2018)
+5.1.1 (October 4th, 2018)
 - Change get_treatments so that it sends a single latency metric
 - Removed unused call to Redis#scan when adding latencies
 - Removed Redis calls on initialization when SDK is set to consumer mode

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-5.1.2 (DATE TBD)
+5.1.2 (October 26th, 2018)
 - Add input validation for client API methods
 
 5.1.1 (October 4th, 2018)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+5.1.2 (DATE TBD)
+- Add input validation for client API methods
+
 5.1.1 (October 4th, 2018)
 - Change get_treatments so that it sends a single latency metric
 - Removed unused call to Redis#scan when adding latencies

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+5.1.2
+
+Add input validation for client API methods: get_treatment, get_treatments, track, manager
+
 5.1.1
 
 Reduces the number of calls to Redis when calling #client.get_treatments using such cache adapter.

--- a/lib/splitclient-rb.rb
+++ b/lib/splitclient-rb.rb
@@ -2,8 +2,7 @@ require 'forwardable'
 
 require 'splitclient-rb/version'
 
-require 'splitclient-rb/exceptions/impressions_shutdown_exception'
-require 'splitclient-rb/exceptions/sdk_blocker_timeout_expired_exception'
+require 'splitclient-rb/exceptions'
 require 'splitclient-rb/cache/routers/impression_router'
 require 'splitclient-rb/cache/adapters/memory_adapters/map_adapter'
 require 'splitclient-rb/cache/adapters/memory_adapters/queue_adapter'
@@ -80,6 +79,7 @@ require 'splitclient-rb/engine/models/split'
 require 'splitclient-rb/engine/models/label'
 require 'splitclient-rb/engine/models/treatment'
 require 'splitclient-rb/utilitites'
+require 'splitclient-rb/validators'
 
 # C extension
 require 'murmurhash/murmurhash_mri'

--- a/lib/splitclient-rb/cache/adapters/redis_adapter.rb
+++ b/lib/splitclient-rb/cache/adapters/redis_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module SplitIoClient
@@ -85,8 +87,8 @@ module SplitIoClient
         end
 
         # Set
-        alias_method :initialize_set, :initialize_map
-        alias_method :find_sets_by_prefix, :find_strings_by_prefix
+        alias initialize_set initialize_map
+        alias find_sets_by_prefix find_strings_by_prefix
 
         def add_to_set(key, val)
           @redis.sadd(key, val)
@@ -126,7 +128,7 @@ module SplitIoClient
         def get_from_queue(key, count)
           items = @redis.lrange(key, 0, count - 1)
           fetched_count = items.size
-          items_to_remove = (fetched_count == count) ? count : fetched_count
+          items_to_remove = fetched_count == count ? count : fetched_count
 
           @redis.ltrim(key, items_to_remove, -1)
 
@@ -148,9 +150,9 @@ module SplitIoClient
           @redis.incrby(key, inc)
         end
 
-        def pipelined(&block)
+        def pipelined
           @redis.pipelined do
-            block.call
+            yield
           end
         end
 
@@ -158,6 +160,10 @@ module SplitIoClient
           keys = @redis.keys("#{prefix}*")
 
           keys.map { |key| @redis.del(key) }
+        end
+
+        def expire(key, seconds)
+          @redis.expire(key, seconds)
         end
       end
     end

--- a/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
@@ -1,42 +1,44 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Repositories
       module Impressions
-        class MemoryRepository
-
+        class MemoryRepository < ImpressionsRepository
           def initialize(adapter)
             @adapter = adapter
           end
 
           # Store impression data in the selected adapter
-          def add(split_name, data)
-            @adapter.add_to_queue(feature: split_name, impressions: data)
+          def add(matching_key, bucketing_key, split_name, treatment, time)
+            @adapter.add_to_queue(
+              m: metadata,
+              i: impression_data(
+                matching_key,
+                bucketing_key,
+                split_name,
+                treatment,
+                time
+              )
+            )
           rescue ThreadError # queue is full
             if random_sampler.rand(1..1000) <= 2 # log only 0.2 % of the time
-              SplitIoClient.configuration.logger.warn("Dropping impressions. Current size is #{SplitIoClient.configuration.impressions_queue_size}. " \
-                                  "Consider increasing impressions_queue_size")
+              SplitIoClient.configuration.logger.warn("Dropping impressions. Current size is \
+                #{SplitIoClient.configuration.impressions_queue_size}. " \
+                'Consider increasing impressions_queue_size')
             end
           end
 
           def add_bulk(key, bucketing_key, treatments, time)
             treatments.each do |split_name, treatment|
-              add(
-                split_name,
-                'keyName' => key,
-                'bucketingKey' => bucketing_key,
-                'treatment' => treatment[:treatment],
-                'label' => SplitIoClient.configuration.labels_enabled ? treatment[:label] : nil,
-                'changeNumber' => treatment[:change_number],
-                'time' => time
-              )
+              add(key, bucketing_key, split_name, treatment, time)
             end
           end
 
-          def get_batch
-            return [] if SplitIoClient.configuration.impressions_bulk_size == 0
-            @adapter.get_batch(SplitIoClient.configuration.impressions_bulk_size).map do |impression|
-              impression.update(ip: SplitIoClient.configuration.machine_ip)
-            end
+          def batch
+            return [] if SplitIoClient.configuration.impressions_bulk_size.zero?
+
+            @adapter.get_batch(SplitIoClient.configuration.impressions_bulk_size)
           end
 
           private

--- a/lib/splitclient-rb/cache/repositories/impressions_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions_repository.rb
@@ -1,18 +1,46 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Repositories
       # Repository which forwards impressions interface to the selected adapter
       class ImpressionsRepository < Repository
         extend Forwardable
-        def_delegators :@adapter, :add, :add_bulk, :get_batch, :empty?
+        def_delegators :@adapter, :add, :add_bulk, :batch, :empty?
 
         def initialize(adapter)
           @adapter = case adapter.class.to_s
-          when 'SplitIoClient::Cache::Adapters::MemoryAdapter'
-            Repositories::Impressions::MemoryRepository.new(adapter)
-          when 'SplitIoClient::Cache::Adapters::RedisAdapter'
-            Repositories::Impressions::RedisRepository.new(adapter)
-          end
+                     when 'SplitIoClient::Cache::Adapters::MemoryAdapter'
+                       Repositories::Impressions::MemoryRepository.new(adapter)
+                     when 'SplitIoClient::Cache::Adapters::RedisAdapter'
+                       Repositories::Impressions::RedisRepository.new(adapter)
+                     end
+        end
+
+        protected
+
+        def impression_data(matching_key, bucketing_key, split_name, treatment, timestamp)
+          {
+            k: matching_key,
+            b: bucketing_key,
+            f: split_name,
+            t: treatment[:treatment],
+            r: applied_rule(treatment[:label]),
+            c: treatment[:change_number],
+            m: timestamp
+          }
+        end
+
+        def metadata
+          {
+            s: "#{SplitIoClient.configuration.language}-#{SplitIoClient.configuration.version}",
+            i: SplitIoClient.configuration.machine_ip,
+            n: SplitIoClient.configuration.machine_name
+          }
+        end
+
+        def applied_rule(label)
+          SplitIoClient.configuration.labels_enabled ? label : nil
         end
       end
     end

--- a/lib/splitclient-rb/cache/repositories/splits_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/splits_repository.rb
@@ -26,7 +26,7 @@ module SplitIoClient
 
         def get_splits(names)
           splits = {}
-          split_names = names.reject(&:empty?).uniq.map { |name| namespace_key(".split.#{name}") }
+          split_names = names.map { |name| namespace_key(".split.#{name}") }
           splits.merge!(
             @adapter
               .multiple_strings(split_names)

--- a/lib/splitclient-rb/cache/senders/events_sender.rb
+++ b/lib/splitclient-rb/cache/senders/events_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Senders

--- a/lib/splitclient-rb/cache/senders/impressions_formatter.rb
+++ b/lib/splitclient-rb/cache/senders/impressions_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Senders
@@ -7,29 +9,15 @@ module SplitIoClient
         end
 
         def call(raw_impressions)
-          impressions = raw_impressions ? raw_impressions : @impressions_repository.get_batch
-          formatted_impressions = []
+          impressions = raw_impressions || @impressions_repository.batch
           filtered_impressions = filter_impressions(impressions)
 
           return [] if impressions.empty? || filtered_impressions.empty?
 
           formatted_impressions = unique_features(filtered_impressions).each_with_object([]) do |feature, memo|
-            ip = nil
-            current_impressions =
-              filtered_impressions
-                .select { |impression| impression[:feature] == feature }
-                .map do |impression|
-                  ip = impression[:ip]
-                  {
-                    keyName: impression[:impressions]['keyName'] || impression[:impressions]['key_name'],
-                    treatment: impression[:impressions]['treatment'],
-                    time: impression[:impressions]['time'],
-                    bucketingKey: impression[:impressions]['bucketingKey'] || impression[:impressions]['bucketing_key'],
-                    label: impression[:impressions]['label'],
-                    changeNumber: impression[:impressions]['changeNumber'] || impression[:impressions]['change_number'],
-                  }
-                end
-
+            feature_impressions = feature_impressions(filtered_impressions, feature)
+            ip = feature_impressions.first[:m][:i]
+            current_impressions = current_impressions(feature_impressions)
             memo << {
               testName: feature.to_sym,
               keyImpressions: current_impressions,
@@ -42,8 +30,27 @@ module SplitIoClient
 
         private
 
+        def feature_impressions(filtered_impressions, feature)
+          filtered_impressions.select do |impression|
+            impression[:i][:f] == feature
+          end
+        end
+
+        def current_impressions(feature_impressions)
+          feature_impressions.map do |impression|
+            {
+              keyName: impression[:i][:k],
+              treatment: impression[:i][:t],
+              time: impression[:i][:m],
+              bucketingKey: impression[:i][:b],
+              label: impression[:i][:r],
+              changeNumber: impression[:i][:c]
+            }
+          end
+        end
+
         def unique_features(impressions)
-          impressions.map { |impression| impression[:feature] }.uniq
+          impressions.map { |impression| impression[:i][:f] }.uniq
         end
 
         # Filter seen impressions by impression_hash
@@ -61,11 +68,11 @@ module SplitIoClient
         end
 
         def impression_hash(impression)
-          "#{impression[:feature]}:" \
-          "#{impression[:impressions]['keyName']}:" \
-          "#{impression[:impressions]['bucketingKey']}:" \
-          "#{impression[:impressions]['changeNumber']}:" \
-          "#{impression[:impressions]['treatment']}"
+          "#{impression[:i][:f]}:" \
+          "#{impression[:i][:k]}:" \
+          "#{impression[:i][:b]}:" \
+          "#{impression[:i][:c]}:" \
+          "#{impression[:i][:t]}"
         end
       end
     end

--- a/lib/splitclient-rb/cache/senders/impressions_sender.rb
+++ b/lib/splitclient-rb/cache/senders/impressions_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Senders

--- a/lib/splitclient-rb/cache/senders/metrics_sender.rb
+++ b/lib/splitclient-rb/cache/senders/metrics_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SplitIoClient
   module Cache
     module Senders

--- a/lib/splitclient-rb/clients/split_client.rb
+++ b/lib/splitclient-rb/clients/split_client.rb
@@ -136,13 +136,12 @@ module SplitIoClient
 
       return if SplitIoClient.configuration.disable_impressions || !store_impressions
 
-      @impressions_repository.add(split_name,
-        'keyName' => matching_key,
-        'bucketingKey' => bucketing_key,
-        'treatment' => treatment[:treatment],
-        'label' => SplitIoClient.configuration.labels_enabled ? treatment[:label] : nil,
-        'time' => time,
-        'changeNumber' => treatment[:change_number]
+      @impressions_repository.add(
+        matching_key,
+        bucketing_key,
+        split_name,
+        treatment,
+        time
       )
 
       route_impression(split_name, matching_key, bucketing_key, time, treatment, attributes)

--- a/lib/splitclient-rb/engine/models/label.rb
+++ b/lib/splitclient-rb/engine/models/label.rb
@@ -4,5 +4,4 @@ class SplitIoClient::Engine::Models::Label
   EXCEPTION = 'exception'.freeze
   KILLED = 'killed'.freeze
   NOT_IN_SPLIT = 'not in split'.freeze
-  DEFINITION_NOT_FOUND = 'definition not found'.freeze
 end

--- a/lib/splitclient-rb/exceptions.rb
+++ b/lib/splitclient-rb/exceptions.rb
@@ -1,0 +1,7 @@
+module SplitIoClient
+  class SplitIoError < StandardError; end
+
+  class ImpressionShutdownException < SplitIoError; end
+
+  class SDKBlockerTimeoutExpiredException < SplitIoError; end
+end

--- a/lib/splitclient-rb/exceptions/impressions_shutdown_exception.rb
+++ b/lib/splitclient-rb/exceptions/impressions_shutdown_exception.rb
@@ -1,4 +1,0 @@
-module SplitIoClient
-  class ImpressionShutdownException < StandardError
-  end
-end

--- a/lib/splitclient-rb/exceptions/sdk_blocker_timeout_expired_exception.rb
+++ b/lib/splitclient-rb/exceptions/sdk_blocker_timeout_expired_exception.rb
@@ -1,4 +1,0 @@
-module SplitIoClient
-  class SDKBlockerTimeoutExpiredException < StandardError
-  end
-end

--- a/lib/splitclient-rb/managers/split_manager.rb
+++ b/lib/splitclient-rb/managers/split_manager.rb
@@ -43,7 +43,7 @@ module SplitIoClient
     #
     # @returns a split view
     def split(split_name)
-      return unless @splits_repository
+      return unless @splits_repository && SplitIoClient::Validators.valid_split_parameters(split_name)
 
       split = @splits_repository.get_split(split_name)
 
@@ -62,7 +62,6 @@ module SplitIoClient
       rescue StandardError
         treatments = []
       end
-
 
         {
           name: name,

--- a/lib/splitclient-rb/validators.rb
+++ b/lib/splitclient-rb/validators.rb
@@ -1,0 +1,185 @@
+module SplitIoClient
+  module Validators
+    extend self
+
+    def valid_get_treatment_parameters(key, split_name, matching_key, bucketing_key)
+      valid_key?(key) && valid_split_name?(split_name) && valid_matching_key?(matching_key) && valid_bucketing_key?(bucketing_key)
+    end
+
+    def valid_get_treatments_parameters(split_names)
+      valid_split_names?(split_names)
+    end
+
+    def valid_track_parameters(key, traffic_type_name, event_type, value)
+      valid_track_key?(key) && valid_traffic_type_name?(traffic_type_name) && valid_event_type?(event_type) && valid_value?(value)
+    end
+
+    def valid_split_parameters(split_name)
+      valid_split_name?(split_name, :split)
+    end
+
+    private
+
+    def string?(value)
+      value.is_a?(String) || value.is_a?(Symbol)
+    end
+
+    def number_or_string?(value)
+      value.is_a?(Numeric) || string?(value)
+    end
+
+    def log_nil(key, method)
+      SplitIoClient.configuration.logger.error("#{method}: #{key} cannot be nil")
+    end
+
+    def log_string(key, method)
+      SplitIoClient.configuration.logger.error("#{method}: #{key} must be a String or a Symbol")
+    end
+
+    def log_number_or_string(key, method)
+      SplitIoClient.configuration.logger.error("#{method}: #{key} must be a String")
+    end
+
+    def log_convert_numeric(key, method)
+      SplitIoClient.configuration.logger.warn("#{method}: #{key} is not of type String, converting to String")
+    end
+
+    def valid_split_name?(split_name, method=:get_treatment)
+      if split_name.nil?
+        log_nil(:split_name, method)
+        return false
+      end
+
+      unless string?(split_name)
+        log_string(:split_name, method)
+        return false
+      end
+
+      return true
+    end
+
+    def valid_key?(key)
+      if key.nil?
+        log_nil(:key, :get_treatment)
+        return false
+      end
+
+      return true
+    end
+
+    def valid_matching_key?(matching_key)
+      if matching_key.nil?
+        log_nil(:matching_key, :get_treatment)
+        return false
+      end
+
+      unless number_or_string?(matching_key)
+        log_number_or_string(:matching_key, :get_treatment)
+        return false
+      end
+
+      if matching_key.is_a? Numeric
+        log_convert_numeric(:matching_key, :get_treatment)
+      end
+
+      return true
+    end
+
+    def valid_bucketing_key?(bucketing_key)
+      if bucketing_key.nil?
+        SplitIoClient.configuration.logger.warn('get_treatment: key object should have bucketing_key set')
+        return true
+      end
+
+      unless number_or_string?(bucketing_key)
+        log_number_or_string(:bucketing_key, :get_treatment)
+        return false
+      end
+
+      if bucketing_key.is_a? Numeric
+        log_convert_numeric(:bucketing_key, :get_treatment)
+      end
+
+      return true
+    end
+
+    def valid_split_names?(split_names)
+      if split_names.nil?
+        log_nil(:split_names, :get_treatments)
+        return false
+      end
+
+      unless split_names.is_a? Array
+        SplitIoClient.configuration.logger.warn('get_treatments: split_names must be an Array')
+        return false
+      end
+
+      return true
+    end
+
+    def valid_track_key?(key)
+      if key.nil?
+        log_nil(:key, :track)
+        return false
+      end
+
+      unless number_or_string?(key)
+        log_number_or_string(:key, :track)
+        return false
+      end
+
+      if key.is_a? Numeric
+        log_convert_numeric(:key, :track)
+      end
+
+      return true
+    end
+
+    def valid_event_type?(event_type)
+      if event_type.nil?
+        log_nil(:event_type, :track)
+        return false
+      end
+
+      unless string?(event_type)
+        log_string(:event_type, :track)
+        return false
+      end
+
+      if (event_type.to_s =~ /[a-zA-Z0-9][-_\.a-zA-Z0-9]{0,62}/).nil?
+        SplitIoClient.configuration.logger.error('track: event_type must adhere to [a-zA-Z0-9][-_\.a-zA-Z0-9]{0,62}')
+        return false
+      end
+
+      return true
+    end
+
+    def valid_traffic_type_name?(traffic_type_name)
+      if traffic_type_name.nil?
+        log_nil(:traffic_type_name, :track)
+        return false
+      end
+
+      unless string?(traffic_type_name)
+        log_string(:traffic_type_name, :track)
+        return false
+      end
+
+      if traffic_type_name.empty?
+        SplitIoClient.configuration.logger.error('track: traffic_type_name must not be an empty String')
+        return false
+      end
+
+      return true
+    end
+
+    def valid_value?(value)
+      unless value.is_a?(Numeric) || value.nil?
+        SplitIoClient.configuration.logger.error('track: value must be a number')
+        return false
+      end
+
+      return true
+    end
+  end
+end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '5.1.2.pre.rc1'
+  VERSION = '5.1.2'
 end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '5.1.1'
+  VERSION = '5.1.2.pre.rc1'
 end

--- a/spec/cache/repositories/splits_repository_spec.rb
+++ b/spec/cache/repositories/splits_repository_spec.rb
@@ -36,26 +36,6 @@ describe SplitIoClient::Cache::Repositories::SplitsRepository do
         'baz' => { name: 'baz' }
       )
     end
-
-    context 'empty split names' do
-      it 'returns data for non empty split names' do
-        expect(repository.adapter).to receive(:multiple_strings).once.and_call_original
-        expect(repository.get_splits(['foo', '', 'bar'])).to eq(
-          foo: { name: 'foo' },
-          bar: { name: 'bar' }
-        )
-      end
-    end
-
-    context 'repeated split names' do
-      it 'returns data for non repeated split names' do
-        expect(repository.adapter).to receive(:multiple_strings).once.and_call_original
-        expect(repository.get_splits(%w[foo foo bar])).to eq(
-          foo: { name: 'foo' },
-          bar: { name: 'bar' }
-        )
-      end
-    end
   end
 
   include_examples 'SplitsRepository specs', SplitIoClient::Cache::Adapters::MemoryAdapter.new(

--- a/spec/engine/matchers/between_matcher_spec.rb
+++ b/spec/engine/matchers/between_matcher_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe SplitIoClient::BetweenMatcher do
   subject do
     SplitIoClient.configuration = nil
-    SplitIoClient::SplitFactory.new('').client
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
   end
 
   let(:datetime_matcher_splits) do

--- a/spec/engine/matchers/less_than_or_equal_to_matcher_spec.rb
+++ b/spec/engine/matchers/less_than_or_equal_to_matcher_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe SplitIoClient::LessThanOrEqualToMatcher do
   subject do
     SplitIoClient.configuration = nil
-    SplitIoClient::SplitFactory.new('').client
+    SplitIoClient::SplitFactory.new('', logger: Logger.new('/dev/null')).client
   end
 
   let(:date_splits_json) do


### PR DESCRIPTION
This PR  removes the producer mode and makes redis+consumer and memory+standalone the only valid SDK modes

It also fixes a small glitch caused by `api_post` wrapped having different return types based on internal logic