### PR TITLE
Fix for traffic allocation when one percent

### DIFF
--- a/lib/splitclient-rb/engine/parser/evaluator.rb
+++ b/lib/splitclient-rb/engine/parser/evaluator.rb
@@ -51,7 +51,7 @@ module SplitIoClient
               if split[:trafficAllocation] < 100
                 bucket = splitter.bucket(splitter.count_hash(key, split[:trafficAllocationSeed].to_i, legacy_algo))
 
-                if bucket >= split[:trafficAllocation]
+                if bucket > split[:trafficAllocation]
                   return treatment_hash(Models::Label::NOT_IN_SPLIT, split[:defaultTreatment], split[:changeNumber])
                 end
               end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -49,6 +49,9 @@ describe SplitIoClient, type: :client do
     let(:traffic_allocation_json) do
       File.read(File.join(SplitIoClient.root, 'spec/test_data/splits/splits_traffic_allocation.json'))
     end
+    let(:traffic_allocation_one_percent_json) do
+      File.read(File.join(SplitIoClient.root, 'spec/test_data/splits/splits_traffic_allocation_one_percent.json'))
+    end
 
     before :each do
       Redis.new.flushall if @mode.equal?(:consumer)
@@ -495,6 +498,17 @@ describe SplitIoClient, type: :client do
           expect(impressions_repository.batch[0][:i][:r])
             .to eq(SplitIoClient::Engine::Models::Label::NOT_IN_SPLIT)
         end
+      end
+    end
+
+    context 'traffic allocation one percent' do
+      before do
+        load_splits(traffic_allocation_one_percent_json)
+      end
+
+      it 'returns expected treatment' do
+        allow_any_instance_of(SplitIoClient::Splitter).to receive(:bucket).and_return(1)
+        expect(subject.get_treatment('test', 'Traffic_Allocation_One_Percent')).to eq('on')
       end
     end
 

--- a/spec/test_data/splits/splits_traffic_allocation_one_percent.json
+++ b/spec/test_data/splits/splits_traffic_allocation_one_percent.json
@@ -1,0 +1,41 @@
+{
+  "splits": [
+    {
+      "name": "Traffic_Allocation_One_Percent",
+      "algo": 1,
+      "trafficAllocation": 1,
+      "trafficAllocationSeed": -1,
+      "killed": false,
+      "status": "ACTIVE",
+      "defaultTreatment": "default",
+      "seed": -1222652054,
+      "orgId": null,
+      "environment": null,
+      "trafficTypeId": null,
+      "trafficTypeName": null,
+      "conditions": [
+        {
+          "conditionType": "ROLLOUT",
+          "matcherGroup": {
+            "combiner": "AND",
+            "matchers": [
+              {
+              "matcherType": "ALL_KEYS",
+              "negate": false,
+              "userDefinedSegmentMatcherData": null,
+              "whitelistMatcherData": null
+              }
+            ]
+          },
+          "partitions": [
+            {
+            "treatment": "on",
+            "size": 100
+            }
+          ],
+          "label": "in segment all"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the issue caused by setting Traffic Allocation to 1% that causes `get_treatment` to always return Default Treatment

[Branch based off `remove_producer`]