### PR TITLE
Fix compatiblity issue with Faraday < 0.13 with net-http-persistent > 3.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,8 @@
+appraise 'faraday-before-0.13' do
+  gem 'faraday', '>= 0.9', '< 0.13'
+  gem 'net-http-persistent', '~> 3.0'
+end
+
+appraise 'faraday-after-0.13' do
+  gem 'faraday', '> 0.13'
+end

--- a/lib/splitclient-rb/engine/api/client.rb
+++ b/lib/splitclient-rb/engine/api/client.rb
@@ -44,10 +44,30 @@ module SplitIoClient
       private
 
       def api_client
+        if needs_patched_net_http_persistent_adapter?
+          require 'splitclient-rb/engine/api/faraday_adapter/patched_net_http_persistent'
+
+          Faraday::Adapter.register_middleware(
+            net_http_persistent: SplitIoClient::FaradayAdapter::PatchedNetHttpPersistent
+          )
+        end
+
         @api_client ||= Faraday.new do |builder|
           builder.use SplitIoClient::FaradayMiddleware::Gzip
           builder.adapter :net_http_persistent
         end
+      end
+
+      def needs_patched_net_http_persistent_adapter?
+        new_net_http_persistent? && incompatible_faraday_version?
+      end
+
+      def incompatible_faraday_version?
+        Faraday::VERSION.split('.')[0..1].reduce(0) { |sum, ver| sum += ver.to_i } < 13
+      end
+
+      def new_net_http_persistent?
+        Net::HTTP::Persistent::VERSION.split('.').first.to_i >= 3
       end
 
       def common_headers(api_key)

--- a/lib/splitclient-rb/engine/api/faraday_adapter/patched_net_http_persistent.rb
+++ b/lib/splitclient-rb/engine/api/faraday_adapter/patched_net_http_persistent.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module SplitIoClient
+  module FaradayAdapter
+    class PatchedNetHttpPersistent < Faraday::Adapter::NetHttpPersistent
+      ##
+      # Borrowed directly from the latest `NetHttpPersistent` adapter implementation.
+      #
+      # https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http_persistent.rb
+      #
+      def net_http_connection(env)
+        @cached_connection ||=
+          if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
+            Net::HTTP::Persistent.new(name: 'Faraday')
+          else
+            Net::HTTP::Persistent.new('Faraday')
+          end
+
+        proxy_uri                = proxy_uri(env)
+        @cached_connection.proxy = proxy_uri if @cached_connection.proxy_uri != proxy_uri
+        @cached_connection
+      end
+
+      def proxy_uri(env)
+        proxy_uri = nil
+        if (proxy = env[:request][:proxy])
+          proxy_uri      = ::URI::HTTP === proxy[:uri] ? proxy[:uri].dup : ::URI.parse(proxy[:uri].to_s)
+          proxy_uri.user = proxy_uri.password = nil
+          # awful patch for net-http-persistent 2.8 not unescaping user/password
+          (
+          class << proxy_uri;
+            self;
+          end).class_eval do
+            define_method(:user) { proxy[:user] }
+            define_method(:password) { proxy[:password] }
+          end if proxy[:user]
+        end
+        proxy_uri
+      end
+
+      def with_net_http_connection(env)
+        yield net_http_connection(env)
+      end
+    end
+  end
+end

--- a/spec/engine/api/client_spec.rb
+++ b/spec/engine/api/client_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SplitIoClient::Api::Client do
+  describe '#get_api' do
+    it 'makes GET request without error' do
+      url     = 'https://example.org?hello=world'
+      api_key = 'abc-def-ghi'
+      params  = { hello: :world }
+
+      stub_request(:get, url).to_return(status: 200)
+
+      expect { described_class.new.get_api(url, api_key, params) }.not_to raise_error
+    end
+
+    it 'makes POST request without error' do
+      url     = 'https://example.org'
+      api_key = 'abc-def-ghi'
+      data    = { hello: :world }
+
+      stub_request(:post, url).to_return(status: 200)
+
+      expect { described_class.new.post_api(url, api_key, data) }.not_to raise_error
+    end
+
+    incompatible_faraday                = Faraday::VERSION.split('.')[0..1].reduce(0) { |sum, ver| sum += ver.to_i } < 13
+    changed_net_http_persistent_version = Net::HTTP::Persistent::VERSION.split('.').first.to_i >= 3
+
+    if incompatible_faraday && changed_net_http_persistent_version
+      it 'uses PatchedNetHttpPersistent middleware' do
+        url     = 'https://example.org?hello=world'
+        api_key = 'abc-def-ghi'
+        params  = { hello: :world }
+
+        stub_request(:get, url).to_return(status: 200)
+
+        expect_any_instance_of(SplitIoClient::FaradayAdapter::PatchedNetHttpPersistent)
+          .to receive(:net_http_connection).and_call_original
+
+        described_class.new.get_api(url, api_key, params)
+      end
+    end
+  end
+end

--- a/splitclient-rb.gemspec
+++ b/splitclient-rb.gemspec
@@ -46,6 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'appraisal'
+  spec.add_development_dependency 'byebug'
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_runtime_dependency 'faraday', '>= 0.8'


### PR DESCRIPTION
### Overview

`Splitio` supports `Faraday (>= 0.8)` and `net-http-persistent (>= 2.9)`. Faraday below `0.13` with `net-http-persistent` >= 3.0 doesn't work.

This PR patches the Faraday's net HTTP persistent adapter to work with the older Faraday with a later net persistent gem.

