### PR TITLE
Passed in redis url is ignored and always defaults to REDIS_URL env var

### DIFF
--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -43,7 +43,7 @@ module SplitIoClient
       @redis_url = opts[:redis_url] || SplitConfig.default_redis_url
       @redis_namespace = opts[:redis_namespace] ? "#{opts[:redis_namespace]}.#{SplitConfig.default_redis_namespace}" : SplitConfig.default_redis_namespace
       @cache_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, redis_url: @redis_url
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, nil, @redis_url
       )
       @connection_timeout = opts[:connection_timeout] || SplitConfig.default_connection_timeout
       @read_timeout = opts[:read_timeout] || SplitConfig.default_read_timeout
@@ -54,7 +54,7 @@ module SplitIoClient
       @impressions_refresh_rate = opts[:impressions_refresh_rate] || SplitConfig.default_impressions_refresh_rate
       @impressions_queue_size = opts[:impressions_queue_size] || SplitConfig.default_impressions_queue_size
       @impressions_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, queue_size: @impressions_queue_size, redis_url: @redis_url
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @impressions_queue_size, @redis_url
       )
       #Safeguard for users of older SDK versions.
       @disable_impressions = @impressions_queue_size == -1
@@ -62,7 +62,7 @@ module SplitIoClient
       @impressions_bulk_size = opts[:impressions_bulk_size] || @impressions_queue_size > 0 ? @impressions_queue_size : 0
 
       @metrics_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, redis_url: @redis_url
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :map_adapter, nil, @redis_url
       )
 
       @logger = opts[:logger] || SplitConfig.default_logger
@@ -88,7 +88,7 @@ module SplitIoClient
       @events_push_rate = opts[:events_push_rate] || SplitConfig.default_events_push_rate
       @events_queue_size = opts[:events_queue_size] || SplitConfig.default_events_queue_size
       @events_adapter = SplitConfig.init_cache_adapter(
-        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, queue_size: @events_queue_size, redis_url: @redis_url
+        opts[:cache_adapter] || SplitConfig.default_cache_adapter, :queue_adapter, @events_queue_size, @redis_url
       )
 
       startup_log
@@ -240,7 +240,7 @@ module SplitIoClient
       'https://events.split.io/api/'
     end
 
-    def self.init_cache_adapter(adapter, data_structure, redis_url: nil, queue_size: nil)
+    def self.init_cache_adapter(adapter, data_structure, queue_size = nil, redis_url = nil)
       case adapter
       when :memory
         SplitIoClient::Cache::Adapters::MemoryAdapter.new(map_memory_adapter(data_structure, queue_size))

--- a/spec/cache/stores/segment_store_spec.rb
+++ b/spec/cache/stores/segment_store_spec.rb
@@ -68,10 +68,11 @@ describe SplitIoClient::Cache::Stores::SegmentStore do
   context 'redis adapter' do
     before do
       Redis.new.flushall
-      cache_adapter = SplitIoClient::SplitConfig.init_cache_adapter(:redis, :map_adapter)
+      cache_adapter = SplitIoClient::SplitConfig.init_cache_adapter(:redis, :map_adapter, redis_url: config.redis_url)
       SplitIoClient.configuration.cache_adapter = cache_adapter
     end
-    let(:adapter) { SplitIoClient::Cache::Adapters::RedisAdapter.new(SplitIoClient::SplitConfig.new.redis_url) }
+    let(:config) { SplitIoClient::SplitConfig.new }
+    let(:adapter) { SplitIoClient::Cache::Adapters::RedisAdapter.new(config.redis_url) }
     let(:segments_repository) { SplitIoClient::Cache::Repositories::SegmentsRepository.new(adapter) }
     let(:splits_repository) { SplitIoClient::Cache::Repositories::SplitsRepository.new(adapter) }
     let(:segment_store) { described_class.new(segments_repository, '', metrics) }

--- a/spec/cache/stores/segment_store_spec.rb
+++ b/spec/cache/stores/segment_store_spec.rb
@@ -68,7 +68,7 @@ describe SplitIoClient::Cache::Stores::SegmentStore do
   context 'redis adapter' do
     before do
       Redis.new.flushall
-      cache_adapter = SplitIoClient::SplitConfig.init_cache_adapter(:redis, :map_adapter, redis_url: config.redis_url)
+      cache_adapter = SplitIoClient::SplitConfig.init_cache_adapter(:redis, :map_adapter, nil, config.redis_url)
       SplitIoClient.configuration.cache_adapter = cache_adapter
     end
     let(:config) { SplitIoClient::SplitConfig.new }


### PR DESCRIPTION
The client allows to pass a `redis_url` in the init params, but never uses it.
 It saves the url in the `@redis_url` *instance* var of the split config. When the param is used, in the `SplitConfig. init_cache_adapter` it tries to reach to `@redis_url`, but since this method is in the class context, and not in the instance context, it will always be`nil`. Therefore passing `nil` to `SplitIoClient::Cache::Adapters::RedisAdapter.new`, which in turn eventually defaults to `REDIS_URL` config var in the `redis` client itself.