### PR TITLE
Update destroy

### DIFF
--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -280,6 +280,8 @@ The following values can be customized:
 
 **block_until_ready** : The SDK will block your app for the provided amount of seconds until it's ready. A `SplitIoClient::SDKBlockerTimeoutExpiredException` will be thrown If the provided time expires. When `0` is provided, the SDK runs in non-blocking mode.
 
+_When using consumer mode, blocking has no effect._
+
 *default value* = `0`
 
 **labels_enabled** : Allows preventing labels from being sent to the Split servers, as they may contain sensitive information.
@@ -349,11 +351,8 @@ options = {
   mode: :consumer,
   redis_url: 'redis://127.0.0.1:6379/0'
 }
-begin
-  split_client = SplitIoClient::SplitFactoryBuilder.build('YOUR_API_KEY', options).client
-rescue SplitIoClient::SDKBlockerTimeoutExpiredException
-  # Code to treat raised exception
-end
+
+split_client = SplitIoClient::SplitFactoryBuilder.build('YOUR_API_KEY', options).client
 ```
 
 ### Logging

--- a/lib/splitclient-rb/cache/adapters/cache_adapter.rb
+++ b/lib/splitclient-rb/cache/adapters/cache_adapter.rb
@@ -19,7 +19,6 @@ module SplitIoClient
 
         def clear(namespace_key)
           @cache.clear
-          @adapter.clear(namespace_key)
         end
 
         def string(key)

--- a/lib/splitclient-rb/cache/adapters/redis_adapter.rb
+++ b/lib/splitclient-rb/cache/adapters/redis_adapter.rb
@@ -125,6 +125,7 @@ module SplitIoClient
           @redis.rpush(key, val)
         end
 
+        # count = 0 will result in lrange(0,-1), fetching all items
         def get_from_queue(key, count)
           items = @redis.lrange(key, 0, count - 1)
           fetched_count = items.size
@@ -157,9 +158,7 @@ module SplitIoClient
         end
 
         def clear(prefix)
-          keys = @redis.keys("#{prefix}*")
-
-          keys.map { |key| @redis.del(key) }
+          # noop
         end
 
         def expire(key, seconds)

--- a/lib/splitclient-rb/cache/repositories/events/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events/memory_repository.rb
@@ -19,6 +19,10 @@ module SplitIoClient
             @adapter.clear
           end
 
+          def batch
+            @adapter.get_batch(EVENTS_SLICE)
+          end
+
           def clear
             @adapter.clear
           end

--- a/lib/splitclient-rb/cache/repositories/events/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events/redis_repository.rb
@@ -16,11 +16,23 @@ module SplitIoClient
             )
           end
 
-          def clear
-            @adapter.get_from_queue(namespace_key('.events'), EVENTS_SLICE).map do |e|
+          def get_events(number_of_events = 0)
+            @adapter.get_from_queue(namespace_key('.events'), number_of_events).map do |e|
               JSON.parse(e, symbolize_names: true)
             end
+          rescue StandardError => e
+            SplitIoClient.configuration.logger.error("Exception while clearing events cache: #{e}")
+            []
           end
+
+          def batch
+            get_events(EVENTS_SLICE)
+          end
+
+          def clear
+            get_events
+          end
+
         end
       end
     end

--- a/lib/splitclient-rb/cache/repositories/events_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/events_repository.rb
@@ -4,7 +4,7 @@ module SplitIoClient
       # Repository which forwards events interface to the selected adapter
       class EventsRepository < Repository
         extend Forwardable
-        def_delegators :@adapter, :add, :clear
+        def_delegators :@adapter, :add, :clear, :batch
 
         def initialize(adapter)
           @adapter = case adapter.class.to_s

--- a/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions/memory_repository.rb
@@ -41,6 +41,10 @@ module SplitIoClient
             @adapter.get_batch(SplitIoClient.configuration.impressions_bulk_size)
           end
 
+          def clear
+            @adapter.clear
+          end
+
           private
 
           def random_sampler

--- a/lib/splitclient-rb/cache/repositories/impressions/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions/redis_repository.rb
@@ -35,8 +35,8 @@ module SplitIoClient
             @adapter.expire(key, EXPIRE_SECONDS) if impressions.size == impressions_list_size
           end
 
-          def batch
-            @adapter.get_from_queue(key, SplitIoClient.configuration.impressions_bulk_size).map do |e|
+          def get_impressions(number_of_impressions = 0)
+            @adapter.get_from_queue(key, number_of_impressions).map do |e|
               impression = JSON.parse(e, symbolize_names: true)
               impression[:i][:f] = impression[:i][:f].to_sym
               impression
@@ -44,6 +44,14 @@ module SplitIoClient
           rescue StandardError => e
             SplitIoClient.configuration.logger.error("Exception while clearing impressions cache: #{e}")
             []
+          end
+
+          def batch
+            get_impressions(SplitIoClient.configuration.impressions_bulk_size)
+          end
+
+          def clear
+            get_impressions
           end
 
           def key

--- a/lib/splitclient-rb/cache/repositories/impressions_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/impressions_repository.rb
@@ -6,7 +6,7 @@ module SplitIoClient
       # Repository which forwards impressions interface to the selected adapter
       class ImpressionsRepository < Repository
         extend Forwardable
-        def_delegators :@adapter, :add, :add_bulk, :batch, :empty?
+        def_delegators :@adapter, :add, :add_bulk, :batch, :clear, :empty?
 
         def initialize(adapter)
           @adapter = case adapter.class.to_s

--- a/lib/splitclient-rb/cache/repositories/segments_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/segments_repository.rb
@@ -13,7 +13,7 @@ module SplitIoClient
           else
             adapter
           end
-          @adapter.set_bool(namespace_key('.ready'), false) unless SplitIoClient.configuration.mode == :consumer
+          @adapter.set_bool(namespace_key('.ready'), false) unless SplitIoClient.configuration.mode.equal?(:consumer)
         end
 
         # Receives segment data, adds and removes segements from the store

--- a/lib/splitclient-rb/cache/repositories/splits_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/splits_repository.rb
@@ -13,7 +13,7 @@ module SplitIoClient
           else
             adapter
           end
-          unless SplitIoClient.configuration.mode == :consumer
+          unless SplitIoClient.configuration.mode.equal?(:consumer)
             @adapter.set_string(namespace_key('.splits.till'), '-1')
             @adapter.initialize_map(namespace_key('.segments.registered'))
           end

--- a/lib/splitclient-rb/cache/senders/impressions_formatter.rb
+++ b/lib/splitclient-rb/cache/senders/impressions_formatter.rb
@@ -8,8 +8,9 @@ module SplitIoClient
           @impressions_repository = impressions_repository
         end
 
-        def call(raw_impressions)
-          impressions = raw_impressions || @impressions_repository.batch
+        def call(fetch_all_impressions, raw_impressions = nil)
+          impressions = raw_impressions || (fetch_all_impressions ? @impressions_repository.clear : @impressions_repository.batch)
+          
           filtered_impressions = filter_impressions(impressions)
 
           return [] if impressions.empty? || filtered_impressions.empty?

--- a/lib/splitclient-rb/cache/senders/metrics_sender.rb
+++ b/lib/splitclient-rb/cache/senders/metrics_sender.rb
@@ -25,12 +25,18 @@ module SplitIoClient
 
         def metrics_thread
           SplitIoClient.configuration.threads[:metrics_sender] = Thread.new do
-            SplitIoClient.configuration.logger.info('Starting metrics service')
+            begin
+              SplitIoClient.configuration.logger.info('Starting metrics service')
+              
+              loop do
+                post_metrics
 
-            loop do
+                sleep(SplitIoClient::Utilities.randomize_interval(SplitIoClient.configuration.metrics_refresh_rate))
+              end
+            rescue SplitIoClient::SDKShutdownException
               post_metrics
 
-              sleep(SplitIoClient::Utilities.randomize_interval(SplitIoClient.configuration.metrics_refresh_rate))
+              SplitIoClient.configuration.logger.info('Posting metrics due to shutdown')
             end
           end
         end

--- a/lib/splitclient-rb/engine/parser/split_adapter.rb
+++ b/lib/splitclient-rb/engine/parser/split_adapter.rb
@@ -20,7 +20,7 @@ module SplitIoClient
     # @param splits_repository [SplitsRepository] SplitsRepository instance to store splits in
     # @param segments_repository [SegmentsRepository] SegmentsRepository instance to store segments in
     # @param impressions_repository [ImpressionsRepository] ImpressionsRepository instance to store impressions in
-    # @param metrics_repository [MetricsRepository] SplitsRepository instance to store metrics in
+    # @param metrics_repository [MetricsRepository] MetricsRepository instance to store metrics in
     # @param sdk_blocker [SDKBlocker] SDKBlocker instance which blocks splits_repository/segments_repository
     #
     # @return [SplitIoClient] split.io client instance

--- a/lib/splitclient-rb/exceptions.rb
+++ b/lib/splitclient-rb/exceptions.rb
@@ -1,7 +1,7 @@
 module SplitIoClient
   class SplitIoError < StandardError; end
 
-  class ImpressionShutdownException < SplitIoError; end
+  class SDKShutdownException < SplitIoError; end
 
   class SDKBlockerTimeoutExpiredException < SplitIoError; end
 end

--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -70,7 +70,7 @@ module SplitIoClient
       @transport_debug_enabled = opts[:transport_debug_enabled] || SplitConfig.default_debug
       @block_until_ready = opts[:ready] || opts[:block_until_ready] || 0
 
-      @logger.warn 'no ready parameter has been set - incorrect control treatments could be logged' if block_until_ready == 0
+      @logger.warn 'no ready parameter has been set - incorrect control treatments could be logged' if block_until_ready == 0 && !mode.equal?(:consumer) 
 
       @machine_name = opts[:machine_name] || SplitConfig.machine_hostname
       @machine_ip = opts[:machine_ip] || SplitConfig.machine_ip

--- a/spec/cache/senders/events_sender_spec.rb
+++ b/spec/cache/senders/events_sender_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SplitIoClient::Cache::Senders::EventsSender do
+  RSpec.shared_examples 'events sender specs' do |cache_adapter|
+    let(:adapter) { cache_adapter }
+    let(:repository) { SplitIoClient::Cache::Repositories::EventsRepository.new(adapter) }
+    let(:sender) { described_class.new(repository, nil) }
+    let(:ip) { SplitIoClient.configuration.machine_ip }
+
+    before :each do
+      Redis.new.flushall
+    end
+
+    it 'calls #post_events upon destroy' do
+      expect(sender).to receive(:post_events).with(no_args)
+
+      sender.send(:events_thread)
+
+      sender_thread = SplitIoClient.configuration.threads[:events_sender]
+
+      sender_thread.raise(SplitIoClient::SDKShutdownException)
+
+      sender_thread.join
+    end
+  end
+
+  include_examples 'events sender specs', SplitIoClient::Cache::Adapters::MemoryAdapter.new(
+    SplitIoClient::Cache::Adapters::MemoryAdapters::QueueAdapter.new(3)
+  )
+  include_examples 'events sender specs', SplitIoClient::Cache::Adapters::RedisAdapter.new(
+    SplitIoClient::SplitConfig.new.redis_url
+  )
+end

--- a/spec/cache/senders/impressions_formatter_spec.rb
+++ b/spec/cache/senders/impressions_formatter_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SplitIoClient::Cache::Senders::ImpressionsFormatter do
+  RSpec.shared_examples 'impressions formatter specs' do |cache_adapter|
+    let(:adapter) { cache_adapter }
+    let(:repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(adapter) }
+    let(:formatter) { described_class.new(repository) }
+    let(:formatted_impressions) { formatter.send(:call, true) }
+    let(:ip) { SplitIoClient.configuration.machine_ip }
+    let(:treatment1) { { treatment: 'on', label: 'custom_label1', change_number: 123_456 } }
+    let(:treatment2) { { treatment: 'off', label: 'custom_label2', change_number: 123_499 } }
+    let(:treatment3) { { treatment: 'off', label: nil, change_number: nil } }
+
+    before :each do
+      Redis.new.flushall
+      SplitIoClient.configuration.impressions_queue_size = 5
+      repository.add('matching_key', 'foo1', 'foo1', treatment1, 1_478_113_516_002)
+      repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
+    end
+
+    it 'formats impressions to be sent' do
+      expect(formatted_impressions)
+        .to match_array([{
+                          testName: :foo1,
+                          keyImpressions: [{ keyName: 'matching_key',
+                                             treatment: 'on',
+                                             time: 1_478_113_516_002,
+                                             bucketingKey: 'foo1', label: 'custom_label1',
+                                             changeNumber: 123_456 }],
+                          ip: ip
+                        },
+                         {
+                           testName: :foo2,
+                           keyImpressions: [{ keyName: 'matching_key2',
+                                              treatment: 'off',
+                                              time: 1_478_113_518_285,
+                                              bucketingKey: 'foo2',
+                                              label: 'custom_label2',
+                                              changeNumber: 123_499 }],
+                           ip: ip
+                         }])
+    end
+
+    it 'formats multiple impressions for one key' do
+      repository.add('matching_key3', nil, 'foo2', treatment3, 1_478_113_518_900)
+
+      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions]).to match_array(
+        [
+          {
+            keyName: 'matching_key',
+            treatment: 'on',
+            time: 1_478_113_516_002,
+            bucketingKey: 'foo1',
+            label: 'custom_label1',
+            changeNumber: 123_456
+          }
+        ]
+      )
+
+      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions]).to match_array(
+        [
+          {
+            keyName: 'matching_key2',
+            treatment: 'off',
+            time: 1_478_113_518_285,
+            bucketingKey: 'foo2',
+            label: 'custom_label2',
+            changeNumber: 123_499
+          },
+          {
+            keyName: 'matching_key3',
+            treatment: 'off',
+            time: 1_478_113_518_900,
+            bucketingKey: nil,
+            label: nil,
+            changeNumber: nil
+          }
+        ]
+      )
+    end
+
+    it 'filters out impressions with the same key/treatment' do
+      repository.add('matching_key', 'foo1', 'foo1', treatment1, 1_478_113_516_902)
+      repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
+
+      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions].size).to eq(1)
+      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions].size).to eq(1)
+    end
+
+    it 'filters out impressions with the same key/treatment legacy' do
+      Redis.new.flushall
+      repository.add('matching_key', 'foo1', 'foo1', treatment1, 1_478_113_516_902)
+      repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
+
+      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions].size).to eq(1)
+      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions].size).to eq(1)
+    end
+  end
+
+  include_examples 'impressions formatter specs', SplitIoClient::Cache::Adapters::MemoryAdapter.new(
+    SplitIoClient::Cache::Adapters::MemoryAdapters::QueueAdapter.new(3)
+  )
+  include_examples 'impressions formatter specs', SplitIoClient::Cache::Adapters::RedisAdapter.new(
+    SplitIoClient::SplitConfig.new.redis_url
+  )
+end

--- a/spec/cache/senders/impressions_sender_spec.rb
+++ b/spec/cache/senders/impressions_sender_spec.rb
@@ -7,11 +7,10 @@ describe SplitIoClient::Cache::Senders::ImpressionsSender do
     let(:adapter) { cache_adapter }
     let(:repository) { SplitIoClient::Cache::Repositories::ImpressionsRepository.new(adapter) }
     let(:sender) { described_class.new(repository, nil) }
-    let(:formatted_impressions) { sender.send(:formatted_impressions, repository.batch) }
+    let(:formatted_impressions) { ImpressionsFormatter.new(repository).call(true) }
     let(:ip) { SplitIoClient.configuration.machine_ip }
     let(:treatment1) { { treatment: 'on', label: 'custom_label1', change_number: 123_456 } }
     let(:treatment2) { { treatment: 'off', label: 'custom_label2', change_number: 123_499 } }
-    let(:treatment3) { { treatment: 'off', label: nil, change_number: nil } }
 
     before :each do
       Redis.new.flushall
@@ -20,87 +19,20 @@ describe SplitIoClient::Cache::Senders::ImpressionsSender do
       repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
     end
 
-    it 'formats impressions to be sent' do
-      expect(formatted_impressions)
-        .to match_array([{
-                          testName: :foo1,
-                          keyImpressions: [{ keyName: 'matching_key',
-                                             treatment: 'on',
-                                             time: 1_478_113_516_002,
-                                             bucketingKey: 'foo1', label: 'custom_label1',
-                                             changeNumber: 123_456 }],
-                          ip: ip
-                        },
-                         {
-                           testName: :foo2,
-                           keyImpressions: [{ keyName: 'matching_key2',
-                                              treatment: 'off',
-                                              time: 1_478_113_518_285,
-                                              bucketingKey: 'foo2',
-                                              label: 'custom_label2',
-                                              changeNumber: 123_499 }],
-                           ip: ip
-                         }])
-    end
-
-    it 'formats multiple impressions for one key' do
-      repository.add('matching_key3', nil, 'foo2', treatment3, 1_478_113_518_900)
-
-      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions]).to match_array(
-        [
-          {
-            keyName: 'matching_key',
-            treatment: 'on',
-            time: 1_478_113_516_002,
-            bucketingKey: 'foo1',
-            label: 'custom_label1',
-            changeNumber: 123_456
-          }
-        ]
-      )
-
-      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions]).to match_array(
-        [
-          {
-            keyName: 'matching_key2',
-            treatment: 'off',
-            time: 1_478_113_518_285,
-            bucketingKey: 'foo2',
-            label: 'custom_label2',
-            changeNumber: 123_499
-          },
-          {
-            keyName: 'matching_key3',
-            treatment: 'off',
-            time: 1_478_113_518_900,
-            bucketingKey: nil,
-            label: nil,
-            changeNumber: nil
-          }
-        ]
-      )
-    end
-
-    it 'filters out impressions with the same key/treatment' do
-      repository.add('matching_key', 'foo1', 'foo1', treatment1, 1_478_113_516_902)
-      repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
-
-      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions].size).to eq(1)
-      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions].size).to eq(1)
-    end
-
-    it 'filters out impressions with the same key/treatment legacy' do
-      Redis.new.flushall
-      repository.add('matching_key', 'foo1', 'foo1', treatment1, 1_478_113_516_902)
-      repository.add('matching_key2', 'foo2', 'foo2', treatment2, 1_478_113_518_285)
-
-      expect(formatted_impressions.find { |i| i[:testName] == :foo1 }[:keyImpressions].size).to eq(1)
-      expect(formatted_impressions.find { |i| i[:testName] == :foo2 }[:keyImpressions].size).to eq(1)
-    end
-
     it 'returns the total number of impressions' do
-      impressions = formatted_impressions
-      expect(sender.send(:impressions_api).total_impressions(impressions)).to eq(2)
+      expect(sender.send(:impressions_api).total_impressions(formatted_impressions)).to eq(2)
+    end
+
+    it 'calls #post_impressions upon destroy' do
+      expect(sender).to receive(:post_impressions).with(no_args)
+
+      sender.send(:impressions_thread)
+
+      sender_thread = SplitIoClient.configuration.threads[:impressions_sender]
+
+      sender_thread.raise(SplitIoClient::SDKShutdownException)
+
+      sender_thread.join
     end
   end
 

--- a/spec/cache/senders/metrics_sender_spec.rb
+++ b/spec/cache/senders/metrics_sender_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SplitIoClient::Cache::Senders::MetricsSender do
+  RSpec.shared_examples 'metrics sender specs' do |cache_adapter|
+    let(:adapter) { cache_adapter }
+    let(:repository) { SplitIoClient::Cache::Repositories::MetricsRepository.new(adapter) }
+    let(:sender) { described_class.new(repository, nil) }
+
+    before :each do
+      Redis.new.flushall
+    end
+
+    it 'calls #post_metrics upon destroy' do
+      expect(sender).to receive(:post_metrics).with(no_args)
+
+      sender.send(:metrics_thread)
+
+      sender_thread = SplitIoClient.configuration.threads[:metrics_sender]
+
+      sender_thread.raise(SplitIoClient::SDKShutdownException)
+
+      sender_thread.join
+    end
+  end
+
+  include_examples 'metrics sender specs', SplitIoClient::Cache::Adapters::MemoryAdapter.new(
+    SplitIoClient::Cache::Adapters::MemoryAdapters::QueueAdapter.new(3)
+  )
+  include_examples 'metrics sender specs', SplitIoClient::Cache::Adapters::RedisAdapter.new(
+    SplitIoClient::SplitConfig.new.redis_url
+  )
+end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -326,7 +326,7 @@ describe SplitIoClient, type: :client do
         impressions = subject.instance_variable_get(:@impressions_repository).batch
         expect(ImpressionsFormatter
           .new(subject.instance_variable_get(:@impressions_repository))
-          .call(impressions)
+          .call(true, impressions)
           .select { |im| im[:testName] == :new_feature }[0][:keyImpressions].size).to eq(2)
       end
 
@@ -498,9 +498,9 @@ describe SplitIoClient, type: :client do
     describe 'impressions' do
       let(:impressions) { subject.instance_variable_get(:@impressions_repository).batch }
       let(:formatted_impressions) do
-        SplitIoClient::Cache::Senders::ImpressionsSender
-          .new(nil, nil)
-          .send(:formatted_impressions, impressions)
+        SplitIoClient::Cache::Senders::ImpressionsFormatter
+          .new(nil)
+          .send(:call, true, impressions)
       end
 
       before do
@@ -606,10 +606,7 @@ describe SplitIoClient, type: :client do
 
       it 'returns control' do
         expect(subject.get_treatment('fake_user_id_1', 'test_feature')).to eq 'on'
-
-        SplitIoClient.configuration.threads[:impressions_sender] = Thread.new {}
         subject.destroy
-
         expect(subject.get_treatment('fake_user_id_1', 'test_feature')).to eq 'control'
       end
     end

--- a/spec/splitclient/split_config_spec.rb
+++ b/spec/splitclient/split_config_spec.rb
@@ -68,7 +68,6 @@ describe SplitIoClient do
 
     it 'logs warning when block until ready not set' do
       SplitIoClient::SplitConfig.new(custom_options)
-      # TODO: prevent this warn from being logged in other tests
       expect(log.string).to include 'no ready parameter has been set - incorrect control treatments could be logged'
     end
   end

--- a/spec/splitclient/split_factory_spec.rb
+++ b/spec/splitclient/split_factory_spec.rb
@@ -118,16 +118,15 @@ describe SplitIoClient::SplitFactory do
     end
   end
 
-  context 'when client is detroyed' do
+  context 'when client is destroyed' do
     let(:cache_adapter) { :memory }
     let(:mode) { :standalone }
 
-    it 'log an error client is detroyed' do
+    it 'log an error' do
       stub_request(:get, 'https://sdk.split.io/api/splitChanges?since=-1')
         .to_return(status: 200, body: [])
 
       factory = described_class.new('browser_key', options)
-      SplitIoClient.configuration.threads[:impressions_sender] = Thread.new {}
       factory.client.destroy
       factory.client.get_treatment('key', 'split')
       expect(log.string).to include 'Client has already been destroyed - no calls possible'

--- a/spec/splitclient/split_manager_spec.rb
+++ b/spec/splitclient/split_manager_spec.rb
@@ -75,7 +75,6 @@ describe SplitIoClient do
 
   describe 'client destroy' do
     before do
-      SplitIoClient.configuration.threads[:impressions_sender] = Thread.new {}
       factory.client.destroy
     end
 


### PR DESCRIPTION
Metrics, events, and impressions are sent upon destroy
Main thread waits for posts to Split backend
at_exit registration calls destroy on interrupts
fixes clear not delegated in impressions_repository
