### PR TITLE
Fix for event properties not being sent to backend

### DIFF
--- a/lib/splitclient-rb/engine/api/events.rb
+++ b/lib/splitclient-rb/engine/api/events.rb
@@ -42,7 +42,8 @@ module SplitIoClient
           trafficTypeName: event[:trafficTypeName],
           eventTypeId: event[:eventTypeId],
           value: event[:value].to_f,
-          timestamp: event[:timestamp].to_i
+          timestamp: event[:timestamp].to_i,
+          properties: event[:properties]
         }
       end
     end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '7.0.1.pre.rc2'
+  VERSION = '7.0.1.pre.rc3'
 end


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?
Fixed missing `properties` key, value pairs in payload sent to the backend when posting events in standalone mode.

## How to test new changes?
Added a UT to validate that request body contains the (up to now) missing key, value pair in events.

Changes can also be tested by creating a simple test app that calls `track` adding an event with properties. Such event must be present in the web console afterwards. In addition, if transport logging is enabled, the body of the corresponding POST shall be visible in the log.

## Extra Notes
Also added a UT to validate the impressions request body to prevent further issues.