### PR TITLE
[Bugfix] `fix_latencies` is running every restart by each app server

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 7.0.2 (Nov 11, 2019)
+- Fixed an issue about empty logs.
 - Fixed an issue about reducing scan commands in redis.
 
 7.0.1 (Oct 31, 2019)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,27 +1,30 @@
+7.0.2 (Nov 11, 2019)
+- Fixed an issue about reducing scan commands in redis.
+
 7.0.1 (Oct 31, 2019)
- - Updated localhost mode so that parsing of test files results in JSON data for splits analogous to that returned by the Split backend.
- - Updated localhost mode to parse the mock data into Split objects to keep differences in operation to a minimum.
- - Removed specific spare code dealing with localhost operations.
- - Removed the disable_impressions configuration param.
- - Fixed an issue about Event properties were not sent to be.
- - Added ip_addresses_enabled to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.
- - Fixed an issue about attributes in matchers.
- - Fixed an issue about trying to access a nil property when sending telemetry metrics.
+- Updated localhost mode so that parsing of test files results in JSON data for splits analogous to that returned by the Split backend.
+- Updated localhost mode to parse the mock data into Split objects to keep differences in operation to a minimum.
+- Removed specific spare code dealing with localhost operations.
+- Removed the disable_impressions configuration param.
+- Fixed an issue about Event properties were not sent to be.
+- Added ip_addresses_enabled to enable/disable sending MachineName and MachineIP headers when data is posted to Split Servers.
+- Fixed an issue about attributes in matchers.
+- Fixed an issue about trying to access a nil property when sending telemetry metrics.
 
 7.0.0 (Aug 23, 2019)
- - BREAKING CHANGE: block_until_ready is now a method in both split_client and split_manager that needs to be explicitly called. The block_until_ready parameter is now ignored if passed in the configuration, and defaults to 15s unless passed as a parameter of the block_until_ready method.
- - Added warning to track calls when traffic type does not belong to an existing split (only issued in the online client and when SDK is ready).
- - Added warning to the get_treatment's method family when split does not exist in the current environment (only issued by online client and when SDK is ready).
- - Added warning to the split_manager's split method when split does not exist in the current environment (only issued by online client and when SDK is ready).
- - Added ability to create multiple split_factory instances. Added factory counts and warnings.
- - Added SDK not ready impressions label.
- - Changed the splits method implementation in the splits_repository to make use of get_splits, which outperforms the current implementation.
+- BREAKING CHANGE: block_until_ready is now a method in both split_client and split_manager that needs to be explicitly called. The block_until_ready parameter is now ignored if passed in the configuration, and defaults to 15s unless passed as a parameter of the block_until_ready method.
+- Added warning to track calls when traffic type does not belong to an existing split (only issued in the online client and when SDK is ready).
+- Added warning to the get_treatment's method family when split does not exist in the current environment (only issued by online client and when SDK is ready).
+- Added warning to the split_manager's split method when split does not exist in the current environment (only issued by online client and when SDK is ready).
+- Added ability to create multiple split_factory instances. Added factory counts and warnings.
+- Added SDK not ready impressions label.
+- Changed the splits method implementation in the splits_repository to make use of get_splits, which outperforms the current implementation.
 
 6.4.1 (Jul 26, 2019)
- - Fixed an issue in the latency metrics format preventing the synchronizer from correctly picking them up (consumer mode only). Old keys will be deleted on SDK startup.
+- Fixed an issue in the latency metrics format preventing the synchronizer from correctly picking them up (consumer mode only). Old keys will be deleted on SDK startup.
 
 6.4.0 (Jul 05, 2019)
- - Added properties to track method.
+- Added properties to track method.
 
 6.3.0 (Apr 30, 2019)
 - Added Dynamic Configurations support through two new methods that mimick the regular ones, changing the type of what is returned.

--- a/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
@@ -67,7 +67,7 @@ module SplitIoClient
 
           # introduced to fix incorrect latencies
           def fix_latencies
-            return if @adapter.exists?(impressions_metrics_key('lantencies.cleaned'))
+            return if @adapter.exists?(impressions_metrics_key('latencies.cleaned'))
 
             keys =[]
 
@@ -91,7 +91,7 @@ module SplitIoClient
               end
             end
 
-            @adapter.set_string(impressions_metrics_key('lantencies.cleaned'), '1')
+            @adapter.set_string(impressions_metrics_key('latencies.cleaned'), '1')
           end
 
           def latencies_to_be_deleted_key_pattern_prefix(key)

--- a/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
+++ b/lib/splitclient-rb/cache/repositories/metrics/redis_repository.rb
@@ -67,6 +67,8 @@ module SplitIoClient
 
           # introduced to fix incorrect latencies
           def fix_latencies
+            return if @adapter.exists?(impressions_metrics_key('lantencies.cleaned'))
+
             keys =[]
 
             23.times do |index|
@@ -88,6 +90,8 @@ module SplitIoClient
                 end
               end
             end
+
+            @adapter.set_string(impressions_metrics_key('lantencies.cleaned'), '1')
           end
 
           def latencies_to_be_deleted_key_pattern_prefix(key)

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '7.0.1'
+  VERSION = '7.0.2'
 end

--- a/spec/cache/repositories/metrics_repository_spec.rb
+++ b/spec/cache/repositories/metrics_repository_spec.rb
@@ -152,7 +152,7 @@ describe SplitIoClient::Cache::Repositories::MetricsRepository do
 
       lc_key = "#{config.redis_namespace}"\
         "/#{config.language}-#{config.version}"\
-        "/#{config.machine_ip}/lantencies.cleaned"
+        "/#{config.machine_ip}/latencies.cleaned"
 
       expect(adapter.exists?(lc_key)).to be false
 

--- a/spec/cache/repositories/metrics_repository_spec.rb
+++ b/spec/cache/repositories/metrics_repository_spec.rb
@@ -168,7 +168,7 @@ describe SplitIoClient::Cache::Repositories::MetricsRepository do
           keep_get_treatments_pattern,
           keep_get_treatments_with_config_pattern
         ]
-      )    
+      )
 
       expect(adapter.exists?(lc_key)).to be true
 

--- a/spec/cache/repositories/metrics_repository_spec.rb
+++ b/spec/cache/repositories/metrics_repository_spec.rb
@@ -150,7 +150,15 @@ describe SplitIoClient::Cache::Repositories::MetricsRepository do
 
       expect(adapter.find_strings_by_pattern(latency_pattern).size).to eq 11
 
+      lc_key = "#{config.redis_namespace}"\
+        "/#{config.language}-#{config.version}"\
+        "/#{config.machine_ip}/lantencies.cleaned"
+
+      expect(adapter.exists?(lc_key)).to be false
+
       repository.fix_latencies
+
+      expect(adapter.find_strings_by_pattern(latency_pattern).size).to eq 5
 
       expect(adapter.find_strings_by_pattern(latency_pattern)).to match_array(
         [
@@ -159,6 +167,26 @@ describe SplitIoClient::Cache::Repositories::MetricsRepository do
           keep_get_treatment_pattern3,
           keep_get_treatments_pattern,
           keep_get_treatments_with_config_pattern
+        ]
+      )    
+
+      expect(adapter.exists?(lc_key)).to be true
+
+      # adding a incorrect pattern and check that enter in the if and does not remove it.
+      adapter.set_string(time_pattern, '33')
+
+      repository.fix_latencies
+
+      expect(adapter.find_strings_by_pattern(latency_pattern).size).to eq 6
+
+      expect(adapter.find_strings_by_pattern(latency_pattern)).to match_array(
+        [
+          keep_get_treatment_pattern1,
+          keep_get_treatment_pattern2,
+          keep_get_treatment_pattern3,
+          keep_get_treatments_pattern,
+          keep_get_treatments_with_config_pattern,
+          time_pattern
         ]
       )
     end


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?
We have a reported [issue](https://github.com/splitio/ruby-client/issues/284).

## How to test new changes?
Running the tests and checking in redis if exists the new flag. 

## Extra Notes

