### PR TITLE
[Fix] Check Ruby SDK Redis integration command deprecation warning

### DIFF
--- a/lib/splitclient-rb/cache/adapters/redis_adapter.rb
+++ b/lib/splitclient-rb/cache/adapters/redis_adapter.rb
@@ -160,7 +160,7 @@ module SplitIoClient
         end
 
         def pipelined
-          @redis.pipelined do
+          @redis.pipelined do |pipeline|
             yield
           end
         end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '7.3.4.pre.rc1'
+  VERSION = '7.3.4.pre.rc2'
 end


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?
- Fixed: Check Ruby SDK Redis integration command deprecation warning
