### PR TITLE
Fix typo in SyncManager startup message

### DIFF
--- a/lib/splitclient-rb/engine/sync_manager.rb
+++ b/lib/splitclient-rb/engine/sync_manager.rb
@@ -42,7 +42,7 @@ module SplitIoClient
           connected = false
 
           if @config.streaming_enabled
-            @config.logger.debug('Starting Straming mode ...')
+            @config.logger.debug('Starting Streaming mode ...')
             start_push_status_monitor
             connected = @push_manager.start_sse
           end


### PR DESCRIPTION
There was a typo in a log message that appears when the client boots.

# Ruby SDK

## What did you accomplish?

We fixed the typo!

## How to test new changes?

Boot the client. You're not "streaming" instead of "straming"

## Extra Notes

