### PR TITLE
Blocking :none impression mode. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,4 @@
-on:
-  push:
-    branches:
-      - do-not-send-impressions
-  pull_request:
-    branches:
-      - do-not-send-impressions
+on: [push, pull_request]
 
 jobs:
   test:

--- a/lib/splitclient-rb/cache/senders/impressions_adapter/redis_sender.rb
+++ b/lib/splitclient-rb/cache/senders/impressions_adapter/redis_sender.rb
@@ -29,8 +29,6 @@ module SplitIoClient
             impressions_count.each do |key, value|
               pipeline.hincrby(impressions_count_key, key, value)
             end
-            
-            @future = pipeline.hlen(impressions_count_key)
           end
 
           expire_impressions_count_key(impressions_count, result)

--- a/lib/splitclient-rb/split_config.rb
+++ b/lib/splitclient-rb/split_config.rb
@@ -51,7 +51,7 @@ module SplitIoClient
 
       @segments_refresh_rate = opts[:segments_refresh_rate] || SplitConfig.default_segments_refresh_rate
 
-      @impressions_mode = init_impressions_mode(opts[:impressions_mode])
+      @impressions_mode = init_impressions_mode(opts[:impressions_mode], opts[:cache_adapter])
 
       @impressions_refresh_rate = SplitConfig.init_impressions_refresh_rate(@impressions_mode, opts[:impressions_refresh_rate], SplitConfig.default_impressions_refresh_rate)
       @impressions_queue_size = opts[:impressions_queue_size] || SplitConfig.default_impressions_queue_size
@@ -314,14 +314,16 @@ module SplitIoClient
       :optimized
     end
 
-    def init_impressions_mode(impressions_mode)
+    def init_impressions_mode(impressions_mode, adapter)
       impressions_mode ||= SplitConfig.default_impressions_mode
+
+      return :debug if adapter == :redis
 
       case impressions_mode
       when :debug
         return :debug
-      when :none
-        return :none
+      # when :none  // we not support :none impression mode yet. Defaulting to :optimized mode
+      #  return :none
       else
         @logger.error('You passed an invalid impressions_mode, impressions_mode should be one of the following values: :debug or :optimized. Defaulting to :optimized mode') unless impressions_mode == :optimized
         return :optimized

--- a/lib/splitclient-rb/telemetry/redis/redis_init_producer.rb
+++ b/lib/splitclient-rb/telemetry/redis/redis_init_producer.rb
@@ -30,7 +30,7 @@ module SplitIoClient
       private
 
       def config_key
-        "#{@config.redis_namespace}.telemetry.config"
+        "#{@config.redis_namespace}.telemetry.init"
       end
     end
   end

--- a/lib/splitclient-rb/version.rb
+++ b/lib/splitclient-rb/version.rb
@@ -1,3 +1,3 @@
 module SplitIoClient
-  VERSION = '7.3.5.pre.rc4'
+  VERSION = '7.3.5.pre.rc5'
 end

--- a/spec/engine/common/impression_manager_spec.rb
+++ b/spec/engine/common/impression_manager_spec.rb
@@ -47,7 +47,8 @@ describe SplitIoClient::Engine::Common::ImpressionManager do
                   unique_keys_tracker)
     end
 
-    it 'build & track impression' do
+    # TODO: remove skip test when the sdk support :none mode.
+    xit 'build & track impression' do
       expected =
         {
           m: { s: version, i: ip, n: machine_name },

--- a/spec/telemetry/synchronizer_spec.rb
+++ b/spec/telemetry/synchronizer_spec.rb
@@ -10,7 +10,7 @@ describe SplitIoClient::Telemetry::Synchronizer do
     let(:adapter) { config.telemetry_adapter }
     let(:init_producer) { SplitIoClient::Telemetry::InitProducer.new(config) }    
     let(:synchronizer) { SplitIoClient::Telemetry::Synchronizer.new(config, nil, init_producer, nil, nil) }
-    let(:config_key) { 'synch-test.SPLITIO.telemetry.config' }    
+    let(:config_key) { 'synch-test.SPLITIO.telemetry.init' }    
 
     it 'synchronize_config with data' do
       adapter.redis.del(config_key)

--- a/spec/telemetry/telemetry_init_spec.rb
+++ b/spec/telemetry/telemetry_init_spec.rb
@@ -56,7 +56,7 @@ describe SplitIoClient::Telemetry::InitConsumer do
     let(:config) { SplitIoClient::SplitConfig.new(logger: Logger.new(log), cache_adapter: :redis, redis_namespace: 'telemetry-test') }
     let(:adapter) { config.telemetry_adapter }
     let(:init_producer) { SplitIoClient::Telemetry::InitProducer.new(config) }
-    let(:telemetry_config_key) { 'telemetry-test.SPLITIO.telemetry.config' }
+    let(:telemetry_config_key) { 'telemetry-test.SPLITIO.telemetry.init' }
 
     it 'record config_init' do
       adapter.redis.del(telemetry_config_key)


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?
- Redis: force to :debug mode.
- InMemory: accept :debug or :optimized mode only.


