### PR TITLE
Support Redis 5.x

### DIFF
--- a/splitclient-rb.gemspec
+++ b/splitclient-rb.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'jwt', '>= 1.0.0', '< 3.0'
   spec.add_runtime_dependency 'lru_redux', '~> 1.1'
   spec.add_runtime_dependency 'net-http-persistent', '>= 2.9', '< 5.0'
-  spec.add_runtime_dependency 'redis', '>= 4.0.0', '< 5.0'
+  spec.add_runtime_dependency 'redis', '>= 4.0.0', '< 6.0'
   spec.add_runtime_dependency 'socketry', '>= 0.4', '< 1.0'
   spec.add_runtime_dependency 'thread_safe', '~> 0.3'
 end


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?

Support Redis 5.x in the `.gemspec`

[Redis 5.0.0 release log](https://github.com/redis/redis-rb/blob/v5.0.0/CHANGELOG.md#500)

## How to test new changes?


## Extra Notes

