### PR TITLE
fix: prevent shutdown from hanging forever

### DIFF
--- a/lib/splitclient-rb/exceptions.rb
+++ b/lib/splitclient-rb/exceptions.rb
@@ -1,7 +1,9 @@
 module SplitIoClient
   class SplitIoError < StandardError; end
 
-  class SDKShutdownException < SplitIoError; end
+  # We are deliberatly not inheriting from SplitIoError so that
+  # `rescue StandardError` won't catch and prevent shutdown.
+  class SDKShutdownException < Exception; end
 
   class SDKBlockerTimeoutExpiredException < SplitIoError; end
 


### PR DESCRIPTION
# Ruby SDK

## What did you accomplish?

I prevented `SDKShutdownException` from being silently eaten by `rescue StandardError`, littered throughout the code.

If eaten by a thread then that thread will never be able to `thread.join` and will hang forever.

## How to test new changes?

Do you have ideas?

## Extra Notes

I ran across this problem in 7.0.3 where [`def post_metrics`](https://github.com/splitio/ruby-client/blob/7.0.3/lib/splitclient-rb/cache/senders/metrics_sender.rb#L43-L47) caught and threw away `SDKShutdownException`.

This is still a potential problem in the current version, 8.2.0.

