### PR TITLE
chore: Drop thread_safe dependency

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,7 @@
 CHANGES
 
-8.11.3 (Aug, 28, 2026)
-- Updated dependencies:
-  - Removed thread_safe, superseded by concurrent-ruby.
+8.11.3 (XX, XX, 2026)
+- Updated concurrent-ruby version to higher than 1.0.4, this removed thread_safe, which was merged into  concurrent-ruby.
 
 8.11.2 (Aug, 25, 2026)
 - Fixed a Streaming client thread leak that may occurs when SDK retries after failed initialization of Streaming connection.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 CHANGES
 
+8.11.3 (Aug, 28, 2026)
+- Updated dependencies:
+  - Removed thread_safe, superseded by concurrent-ruby.
+
 8.11.2 (Aug, 25, 2026)
 - Fixed a Streaming client thread leak that may occurs when SDK retries after failed initialization of Streaming connection.
 

--- a/splitclient-rb.gemspec
+++ b/splitclient-rb.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webrick', '~> 1.8.2'
 
   spec.add_runtime_dependency 'bitarray', '~> 1.3'
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0', '> 1.0.5'
   spec.add_runtime_dependency 'faraday', '>= 1.1', '< 3.0'
   spec.add_runtime_dependency 'faraday-net_http_persistent', '>= 1.0', '< 3.0'
   spec.add_runtime_dependency 'json', '>= 1.8', '< 3.0'
@@ -59,5 +59,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'lru_redux', '~> 1.1'
   spec.add_runtime_dependency 'net-http-persistent', '>= 2.9', '< 5.0'
   spec.add_runtime_dependency 'redis', '>= 4.0.0', '< 6.0'
-  spec.add_runtime_dependency 'thread_safe', '~> 0.3'
 end


### PR DESCRIPTION
Since thread_safe was folded into concurrent-ruby, this appears to just be a vestigial dependency that can be dropped. 